### PR TITLE
WIP: RYO ZIP writer implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ pkg
 #
 #.DS_Store
 
+tmp
+
 # For TextMate
 #*.tmproj
 #tmtags

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ cache: bundler
 matrix:
   allow_failures:
     - rvm: jruby-9.0
+script: bundle exec rspec --tag ~long # Skip tests that generate large ZIPs or that take a very long time

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -303,6 +303,7 @@ class ZipTricks::Microzip
                                                               # central directory               4 bytes
       @io << [zip64_eocdr_offset].pack(C_Qe)                  # relative offset of the zip64
                                                               # end of central directory record 8 bytes
+                                                              # (note: "relative" is actually "from the start of the file")
       @io << [1].pack(C_V)                                    # total number of disks           4 bytes
     end
 

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -16,9 +16,6 @@ class ZipTricks::Microzip
   DuplicateFilenames = Class.new(StandardError)
   UnknownMode = Class.new(StandardError)
   
-  private_constant :FOUR_BYTE_MAX_UINT, :TWO_BYTE_MAX_UINT,
-    :VERSION_MADE_BY, :VERSION_NEEDED_TO_EXTRACT, :VERSION_NEEDED_TO_EXTRACT_ZIP64, :Entry
-
   FOUR_BYTE_MAX_UINT = 0xFFFFFFFF
   TWO_BYTE_MAX_UINT = 0xFFFF
 
@@ -319,4 +316,7 @@ class ZipTricks::Microzip
     @io << [0].pack('v')                                    # .ZIP file comment length        2 bytes
                                                             # .ZIP file comment       (variable size)
   end
+  
+  private_constant :FOUR_BYTE_MAX_UINT, :TWO_BYTE_MAX_UINT,
+    :VERSION_MADE_BY, :VERSION_NEEDED_TO_EXTRACT, :VERSION_NEEDED_TO_EXTRACT_ZIP64, :Entry
 end

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -31,7 +31,6 @@ class ZipTricks::Microzip
     def initialize(*)
       super
       @requires_zip64 = (compressed_size > FOUR_BYTE_MAX_UINT || uncompressed_size > FOUR_BYTE_MAX_UINT)
-      @local_file_header_location = :LOCAL_FILE_HEADER_NOT_WRITTEN_YET
     end
 
     def requires_zip64?

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -30,6 +30,11 @@ class ZipTricks::Microzip
   class Entry < Struct.new(:filename, :crc32, :compressed_size, :uncompressed_size, :storage_mode, :mtime)
     def initialize(*)
       super
+      
+      if filename.bytesize > TWO_BYTE_MAX_UINT
+        raise TooMuch, "The given filename is too long to fit (%d bytes)" % filename.bytesize
+      end
+      
       @requires_zip64 = (compressed_size > FOUR_BYTE_MAX_UINT || uncompressed_size > FOUR_BYTE_MAX_UINT)
     end
 

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -274,14 +274,14 @@ class ZipTricks::Microzip
       @io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack(C_v)      # version needed to extract       2 bytes
       @io << [0].pack(C_V)                                    # number of this disk             4 bytes
       @io << [0].pack(C_V)                                    # number of the disk with the
-      @io                                                     # start of the central directory  4 bytes
+                                                              # start of the central directory  4 bytes
       @io << [@files.length].pack(C_Qe)                       # total number of entries in the
-      @io                                                     # central directory on this disk  8 bytes
+                                                              # central directory on this disk  8 bytes
       @io << [@files.length].pack(C_Qe)                       # total number of entries in the
-      @io                                                     # central directory               8 bytes
+                                                              # central directory               8 bytes
       @io << [central_dir_size].pack(C_Qe)                    # size of the central directory   8 bytes
-      @io                                                     # offset of start of central
-      @io                                                     # directory with respect to
+                                                              # offset of start of central
+                                                              # directory with respect to
       @io << [start_of_central_directory].pack(C_Qe)          # the starting disk number        8 bytes
                                                               # zip64 extensible data sector    (variable size)
 

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -260,8 +260,8 @@ class ZipTricks::Microzip
 
     # Central directory file headers, per file in order
     @files.each_with_index do |file, i|
-      offset = @local_header_offsets.fetch(i)
-      file.write_central_directory_file_header(@io, offset)
+      local_file_header_offset_from_start_of_file = @local_header_offsets.fetch(i)
+      file.write_central_directory_file_header(@io, local_file_header_offset_from_start_of_file)
     end
     central_dir_size = @io.tell - start_of_central_directory
 

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -249,7 +249,8 @@ class ZipTricks::Microzip
     start_of_central_directory = @io.tell
 
     # Central directory file headers, per file in order
-    @files.zip(@local_header_offsets).each do |(file, offset)|
+    @files.each_with_index do |file, i|
+      offset = @local_header_offsets.fetch(i)
       file.write_central_directory_file_header(@io, offset)
     end
     central_dir_size = @io.tell - start_of_central_directory

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -50,6 +50,18 @@ class ZipTricks::Microzip
     end
 
     def write_local_file_header(io)
+      # TBD: caveat. If this entry _does_ fit into a standard zip segment (both compressed and
+      # uncompressed size at or below 0xFFFF etc), but it is _located_ at an offset that requires
+      # Zip64 to be used (beyound 4GB), we are going to be omitting the Zip64 extras in the local
+      # file header, but we will be enabling them when writing the central directory. Then the
+      # CD record for the file _will_ have Zip64 extra, but the local file header won't. In theory,
+      # this should not pose a problem, but then again... life in this world can be harsh.
+      #
+      # If it turns out that it _does_ pose a problem, we can always do:
+      #
+      #   @requires_zip64 = true if io.tell > FOUR_BYTE_MAX_UINT
+      #
+      # right here, and have the data written regardless even if the file fits.
       io << [0x04034b50].pack(C_V)                        # local file header signature     4 bytes  (0x04034b50)
 
       if @requires_zip64                                  # version needed to extract       2 bytes
@@ -104,7 +116,6 @@ class ZipTricks::Microzip
       io << [0].pack(C_V)                             # 4 bytes    Number of the disk on which this file starts
     end
 
-=begin
     # I am keeping this for future use (if we want to generate ZIPs with postfix CRCs for instance)
     def write_data_descriptor(io)
       # 4.3.9.3 Although not originally assigned a signature, the value
@@ -132,7 +143,6 @@ class ZipTricks::Microzip
         io << [uncompressed_size].pack(C_V)               # uncompressed size               4 bytes
       end
     end
-=end
 
     def write_central_directory_file_header(io, local_file_header_location)
       # At this point if the header begins somewhere beyound 0xFFFFFFFF we _have_ to record the offset

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -23,6 +23,10 @@ class ZipTricks::Microzip
   VERSION_NEEDED_TO_EXTRACT              = 20
   VERSION_NEEDED_TO_EXTRACT_ZIP64        = 45
 
+  C_V = 'V'.freeze
+  C_v = 'v'.freeze
+  C_Qe = 'Q<'.freeze
+
   class Entry < Struct.new(:filename, :crc32, :compressed_size, :uncompressed_size, :storage_mode, :mtime)
     def initialize(*)
       super
@@ -47,37 +51,37 @@ class ZipTricks::Microzip
     end
 
     def write_local_file_header(io)
-      io << [0x04034b50].pack('V')                        # local file header signature     4 bytes  (0x04034b50)
+      io << [0x04034b50].pack(C_V)                        # local file header signature     4 bytes  (0x04034b50)
 
       if @requires_zip64                                  # version needed to extract       2 bytes
-        io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack('v')
+        io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack(C_v)
       else
-        io << [VERSION_NEEDED_TO_EXTRACT].pack('v')
+        io << [VERSION_NEEDED_TO_EXTRACT].pack(C_v)
       end
 
       io << [gp_flags_based_on_filename].pack("v")        # general purpose bit flag        2 bytes
       io << [storage_mode].pack("v")                      # compression method              2 bytes
-      io << [to_binary_dos_time(mtime)].pack('v')         # last mod file time              2 bytes
-      io << [to_binary_dos_date(mtime)].pack('v')         # last mod file date              2 bytes
-      io << [crc32].pack('V')                             # crc-32                          4 bytes
+      io << [to_binary_dos_time(mtime)].pack(C_v)         # last mod file time              2 bytes
+      io << [to_binary_dos_date(mtime)].pack(C_v)         # last mod file date              2 bytes
+      io << [crc32].pack(C_V)                             # crc-32                          4 bytes
 
       if @requires_zip64
-        io << [FOUR_BYTE_MAX_UINT].pack('V')              # compressed size              4 bytes
-        io << [FOUR_BYTE_MAX_UINT].pack('V')              # uncompressed size            4 bytes
+        io << [FOUR_BYTE_MAX_UINT].pack(C_V)              # compressed size              4 bytes
+        io << [FOUR_BYTE_MAX_UINT].pack(C_V)              # uncompressed size            4 bytes
       else
-        io << [compressed_size].pack('V')                 # compressed size              4 bytes
-        io << [uncompressed_size].pack('V')               # uncompressed size            4 bytes
+        io << [compressed_size].pack(C_V)                 # compressed size              4 bytes
+        io << [uncompressed_size].pack(C_V)               # uncompressed size            4 bytes
       end
 
       # Filename should not be longer than 0xFFFF otherwise this wont fit here
-      io << [filename.bytesize].pack('v')                 # file name length             2 bytes
+      io << [filename.bytesize].pack(C_v)                 # file name length             2 bytes
 
       if @requires_zip64
         tmp = ''.force_encoding(Encoding::BINARY)
         write_zip_64_extra_for_local_file_header(tmp)
-        io << [tmp.bytesize].pack('v')                    # extra field length              2 bytes
+        io << [tmp.bytesize].pack(C_v)                    # extra field length              2 bytes
       else
-        io << [0].pack('v')                               # extra field length              2 bytes
+        io << [0].pack(C_v)                               # extra field length              2 bytes
       end
 
       io << filename                                      # file name (variable size)
@@ -86,19 +90,19 @@ class ZipTricks::Microzip
     end
 
     def write_zip_64_extra_for_local_file_header(io)
-      io << [0x0001].pack('v')                        # 2 bytes    Tag for this "extra" block type
-      io << [16].pack('v')                            # 2 bytes    Size of this "extra" block. For us it will always be 16 (2x8)
-      io << [uncompressed_size].pack('Q<')            # 8 bytes    Original uncompressed file size
-      io << [compressed_size].pack('Q<')              # 8 bytes    Size of compressed data
+      io << [0x0001].pack(C_v)                        # 2 bytes    Tag for this "extra" block type
+      io << [16].pack(C_v)                            # 2 bytes    Size of this "extra" block. For us it will always be 16 (2x8)
+      io << [uncompressed_size].pack(C_Qe)            # 8 bytes    Original uncompressed file size
+      io << [compressed_size].pack(C_Qe)              # 8 bytes    Size of compressed data
     end
 
     def write_zip_64_extra_for_central_directory_file_header(io)
-      io << [0x0001].pack('v')                        # 2 bytes    Tag for this "extra" block type
-      io << [28].pack('v')                            # 2 bytes    Size of this "extra" block. For us it will always be 28
-      io << [uncompressed_size].pack('Q<')            # 8 bytes    Original uncompressed file size
-      io << [compressed_size].pack('Q<')              # 8 bytes    Size of compressed data
-      io << [@local_file_header_location].pack('Q<')  # 8 bytes    Offset of local header record
-      io << [0].pack('V')                             # 4 bytes    Number of the disk on which this file starts
+      io << [0x0001].pack(C_v)                        # 2 bytes    Tag for this "extra" block type
+      io << [28].pack(C_v)                            # 2 bytes    Size of this "extra" block. For us it will always be 28
+      io << [uncompressed_size].pack(C_Qe)            # 8 bytes    Original uncompressed file size
+      io << [compressed_size].pack(C_Qe)              # 8 bytes    Size of compressed data
+      io << [@local_file_header_location].pack(C_Qe)  # 8 bytes    Offset of local header record
+      io << [0].pack(C_V)                             # 4 bytes    Number of the disk on which this file starts
     end
 
 =begin
@@ -112,7 +116,7 @@ class ZipTricks::Microzip
       #    the signature is used, the fields currently defined for
       #    the data descriptor record will immediately follow the
       #    signature.
-      io << [0x08074b50].pack('V')
+      io << [0x08074b50].pack(C_V)
       # 4.3.9.2 When compressing files, compressed and uncompressed sizes
       # should be stored in ZIP64 format (as 8 byte values) when a
       # file's size exceeds 0xFFFFFFFF.   However ZIP64 format may be
@@ -120,13 +124,13 @@ class ZipTricks::Microzip
       # the zip64 extended information extra field is present for
       # the file the compressed and uncompressed sizes will be 8
       # byte values.
-      io << [crc32].pack('V')                             # crc-32                          4 bytes
+      io << [crc32].pack(C_V)                             # crc-32                          4 bytes
       if @requires_zip64
-        io << [compressed_size].pack('Q<')                # compressed size                 8 bytes for ZIP64
-        io << [uncompressed_size].pack('Q<')              # uncompressed size               8 bytes for ZIP64
+        io << [compressed_size].pack(C_Qe)                # compressed size                 8 bytes for ZIP64
+        io << [uncompressed_size].pack(C_Qe)              # uncompressed size               8 bytes for ZIP64
       else
-        io << [compressed_size].pack('V')                 # compressed size                 4 bytes
-        io << [uncompressed_size].pack('V')               # uncompressed size               4 bytes
+        io << [compressed_size].pack(C_V)                 # compressed size                 4 bytes
+        io << [uncompressed_size].pack(C_V)               # uncompressed size               4 bytes
       end
     end
 =end
@@ -136,53 +140,53 @@ class ZipTricks::Microzip
       # of the local file header as a zip64 extra field, so we give up, give in, you loose, love will always win...
       @requires_zip64 = true if local_file_header_location > FOUR_BYTE_MAX_UINT
       
-      io << [0x02014b50].pack('V')                        # central file header signature   4 bytes  (0x02014b50)
-      io << [VERSION_MADE_BY].pack('v')                   # version made by                 2 bytes
+      io << [0x02014b50].pack(C_V)                        # central file header signature   4 bytes  (0x02014b50)
+      io << [VERSION_MADE_BY].pack(C_v)                   # version made by                 2 bytes
       if @requires_zip64
-        io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack('v') # version needed to extract       2 bytes
+        io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack(C_v) # version needed to extract       2 bytes
       else
-        io << [VERSION_NEEDED_TO_EXTRACT].pack('v')       # version needed to extract       2 bytes
+        io << [VERSION_NEEDED_TO_EXTRACT].pack(C_v)       # version needed to extract       2 bytes
       end
 
-      io << [gp_flags_based_on_filename].pack('v')        # general purpose bit flag        2 bytes
-      io << [storage_mode].pack('v')                      # compression method              2 bytes
-      io << [to_binary_dos_time(mtime)].pack('v')         # last mod file time              2 bytes
-      io << [to_binary_dos_date(mtime)].pack('v')         # last mod file date              2 bytes
-      io << [crc32].pack('V')                             # crc-32                          4 bytes
+      io << [gp_flags_based_on_filename].pack(C_v)        # general purpose bit flag        2 bytes
+      io << [storage_mode].pack(C_v)                      # compression method              2 bytes
+      io << [to_binary_dos_time(mtime)].pack(C_v)         # last mod file time              2 bytes
+      io << [to_binary_dos_date(mtime)].pack(C_v)         # last mod file date              2 bytes
+      io << [crc32].pack(C_V)                             # crc-32                          4 bytes
 
       if @requires_zip64
-        io << [FOUR_BYTE_MAX_UINT].pack('V')              # compressed size              4 bytes
-        io << [FOUR_BYTE_MAX_UINT].pack('V')              # uncompressed size            4 bytes
+        io << [FOUR_BYTE_MAX_UINT].pack(C_V)              # compressed size              4 bytes
+        io << [FOUR_BYTE_MAX_UINT].pack(C_V)              # uncompressed size            4 bytes
       else
-        io << [compressed_size].pack('V')                 # compressed size              4 bytes
-        io << [uncompressed_size].pack('V')               # uncompressed size            4 bytes
+        io << [compressed_size].pack(C_V)                 # compressed size              4 bytes
+        io << [uncompressed_size].pack(C_V)               # uncompressed size            4 bytes
       end
 
       # Filename should not be longer than 0xFFFF otherwise this wont fit here
-      io << [filename.bytesize].pack('v')                 # file name length                2 bytes
+      io << [filename.bytesize].pack(C_v)                 # file name length                2 bytes
 
       if @requires_zip64
         local_fh_extra = ''.force_encoding(Encoding::BINARY)
-        write_zip_64_extra_for_central_directory_file_header(local_fh_extra)
-        io << [local_fh_extra.bytesize].pack('v')         # extra field length              2 bytes
+        write_zip_64_extra_for_central_directory_file_header(local_fh_extra, local_file_header_location)
+        io << [local_fh_extra.bytesize].pack(C_v)         # extra field length              2 bytes
       else
-        io << [0].pack('v')                                 # extra field length              2 bytes
+        io << [0].pack(C_v)                                 # extra field length              2 bytes
       end
 
-      io << [0].pack('v')                                 # file comment length             2 bytes
-      io << [0].pack('v')                                 # disk number start               2 bytes
-      io << [0].pack('v')                                 # internal file attributes        2 bytes
-      io << [0].pack('V')                                 # external file attributes        4 bytes
+      io << [0].pack(C_v)                                 # file comment length             2 bytes
+      io << [0].pack(C_v)                                 # disk number start               2 bytes
+      io << [0].pack(C_v)                                 # internal file attributes        2 bytes
+      io << [0].pack(C_V)                                 # external file attributes        4 bytes
 
       if @requires_zip64
-        io << [FOUR_BYTE_MAX_UINT].pack('V')              # relative offset of local header 4 bytes
+        io << [FOUR_BYTE_MAX_UINT].pack(C_V)              # relative offset of local header 4 bytes
       else
-        io << [local_file_header_location].pack('V')     # relative offset of local header 4 bytes
+        io << [local_file_header_location].pack(C_V)     # relative offset of local header 4 bytes
       end
       io << filename                                      # file name (variable size)
 
       if @requires_zip64                                  # extra field (variable size)
-        write_zip_64_extra_for_central_directory_file_header(io)
+        write_zip_64_extra_for_central_directory_file_header(io, local_file_header_location)
       end
                                                           # file comment (variable size)
     end
@@ -261,61 +265,61 @@ class ZipTricks::Microzip
       # [zip64 end of central directory record]
       zip64_eocdr_offset = @io.tell
                                                 # zip64 end of central dir
-      @io << [0x06064b50].pack('V')             # signature                       4 bytes  (0x06064b50)
-      @io << [44].pack('Q<')                    # size of zip64 end of central
+      @io << [0x06064b50].pack(C_V)             # signature                       4 bytes  (0x06064b50)
+      @io << [44].pack(C_Qe)                    # size of zip64 end of central
                                                 # directory record                8 bytes
                                                 # (this is ex. the 12 bytes of the signature and the size value itself).
                                                 # Without the extensible data sector it is always 44.
-      @io << [VERSION_MADE_BY].pack('v')                      # version made by                 2 bytes
-      @io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack('v')      # version needed to extract       2 bytes
-      @io << [0].pack('V')                                    # number of this disk             4 bytes
-      @io << [0].pack('V')                                    # number of the disk with the
+      @io << [VERSION_MADE_BY].pack(C_v)                      # version made by                 2 bytes
+      @io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack(C_v)      # version needed to extract       2 bytes
+      @io << [0].pack(C_V)                                    # number of this disk             4 bytes
+      @io << [0].pack(C_V)                                    # number of the disk with the
       @io                                                     # start of the central directory  4 bytes
-      @io << [@files.length].pack('Q<')                       # total number of entries in the
+      @io << [@files.length].pack(C_Qe)                       # total number of entries in the
       @io                                                     # central directory on this disk  8 bytes
-      @io << [@files.length].pack('Q<')                       # total number of entries in the
+      @io << [@files.length].pack(C_Qe)                       # total number of entries in the
       @io                                                     # central directory               8 bytes
-      @io << [central_dir_size].pack('Q<')                    # size of the central directory   8 bytes
+      @io << [central_dir_size].pack(C_Qe)                    # size of the central directory   8 bytes
       @io                                                     # offset of start of central
       @io                                                     # directory with respect to
-      @io << [start_of_central_directory].pack('Q<')          # the starting disk number        8 bytes
+      @io << [start_of_central_directory].pack(C_Qe)          # the starting disk number        8 bytes
                                                               # zip64 extensible data sector    (variable size)
 
       # [zip64 end of central directory locator]
       @io << [0x07064b50].pack("V")                           # zip64 end of central dir locator
                                                               # signature                       4 bytes  (0x07064b50)
-      @io << [0].pack('V')                                    # number of the disk with the
+      @io << [0].pack(C_V)                                    # number of the disk with the
                                                               # start of the zip64 end of
                                                               # central directory               4 bytes
-      @io << [zip64_eocdr_offset].pack('Q<')                  # relative offset of the zip64
+      @io << [zip64_eocdr_offset].pack(C_Qe)                  # relative offset of the zip64
                                                               # end of central directory record 8 bytes
-      @io << [1].pack('V')                                    # total number of disks           4 bytes
+      @io << [1].pack(C_V)                                    # total number of disks           4 bytes
     end
 
     # Then the end of central directory record:
-    @io << [0x06054b50].pack('V')                           # end of central dir signature     4 bytes  (0x06054b50)
-    @io << [0].pack('v')                                    # number of this disk              2 bytes
-    @io << [0].pack('v')                                    # number of the disk with the
+    @io << [0x06054b50].pack(C_V)                           # end of central dir signature     4 bytes  (0x06054b50)
+    @io << [0].pack(C_v)                                    # number of this disk              2 bytes
+    @io << [0].pack(C_v)                                    # number of the disk with the
                                                             #   start of the central directory 2 bytes
-    @io << [@files.length].pack('v')                        # total number of entries in the
+    @io << [@files.length].pack(C_v)                        # total number of entries in the
                                                             # central directory on this disk   2 bytes
-    @io << [@files.length].pack('v')                        # total number of entries in
+    @io << [@files.length].pack(C_v)                        # total number of entries in
                                                             # the central directory            2 bytes
     if zip64_required
-      @io << [FOUR_BYTE_MAX_UINT].pack('V')                   # size of the central directory    4 bytes
-      @io << [FOUR_BYTE_MAX_UINT].pack('V')                   # offset of start of central
+      @io << [FOUR_BYTE_MAX_UINT].pack(C_V)                   # size of the central directory    4 bytes
+      @io << [FOUR_BYTE_MAX_UINT].pack(C_V)                   # offset of start of central
                                                               # directory with respect to
                                                               # the starting disk number        4 bytes
     else
-      @io << [central_dir_size].pack('V')                     # size of the central directory    4 bytes
-      @io << [start_of_central_directory].pack('V')           # offset of start of central
+      @io << [central_dir_size].pack(C_V)                     # size of the central directory    4 bytes
+      @io << [start_of_central_directory].pack(C_V)           # offset of start of central
                                                               # directory with respect to
                                                               # the starting disk number        4 bytes
     end
-    @io << [0].pack('v')                                    # .ZIP file comment length        2 bytes
+    @io << [0].pack(C_v)                                    # .ZIP file comment length        2 bytes
                                                             # .ZIP file comment       (variable size)
   end
   
   private_constant :FOUR_BYTE_MAX_UINT, :TWO_BYTE_MAX_UINT,
-    :VERSION_MADE_BY, :VERSION_NEEDED_TO_EXTRACT, :VERSION_NEEDED_TO_EXTRACT_ZIP64, :Entry
+    :VERSION_MADE_BY, :VERSION_NEEDED_TO_EXTRACT, :VERSION_NEEDED_TO_EXTRACT_ZIP64, :Entry, :C_V, :C_v, :C_Qe
 end

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -1,0 +1,304 @@
+# A replacement for RubyZip for streaming, with a couple of small differences.
+# The first difference is that it is verbosely-written-to-the-spec and you can actually
+# follow what is happening. It does not support quite a few fancy features of Rubyzip,
+# but instead it can be digested in one reading, and has solid Zip64 support. It also does
+# not attempt any tricks with Zip64 placeholder extra fields because the ZipTricks streaming
+# engine assumes you _know_ how large your file is (both compressed and uncompressed) _and_
+# you have the file's CRC32 checksum upfront.
+#
+# Just like Rubyzip it will switch to Zip64 automatically if required, but there is no global
+# setting for that.
+class ZipTricks::Microzip
+  STORED   = 0
+  DEFLATED = 8
+
+  FOUR_BYTE_MAX_UINT = 0xFFFFFFFF
+  TWO_BYTE_MAX_UINT = 0xFFFF
+
+  VERSION_MADE_BY                        = 52
+  VERSION_NEEDED_TO_EXTRACT              = 20
+  VERSION_NEEDED_TO_EXTRACT_ZIP64        = 45
+
+  TooMuch = Class.new(StandardError)
+  DuplicateFilenames = Class.new(StandardError)
+  UnknownMode = Class.new(StandardError)
+
+  class Entry < Struct.new(:filename, :crc32, :compressed_size, :uncompressed_size, :storage_mode, :mtime)
+    def initialize(*)
+      super
+      @requires_zip64 = (compressed_size > FOUR_BYTE_MAX_UINT || uncompressed_size > FOUR_BYTE_MAX_UINT)
+      @local_file_header_location = :LOCAL_FILE_HEADER_NOT_WRITTEN_YET
+    end
+
+    def requires_zip64?
+      @requires_zip64
+    end
+
+    # Set the general purpose flags for the entry. The only flag we care about is the EFS
+    # bit (bit 11) which should be set if the filename is UTF8. If it is, we need to set the
+    # bit so that the unarchiving application knows that the filename in the archive is UTF-8
+    # encoded, and not some DOS default. For ASCII entries it does not matter.
+    def gp_flags_based_on_filename
+      filename.encode(Encoding::ASCII)
+      0b00000000000
+    rescue Encoding::UndefinedConversionError # UTF8 filename
+      # notify the unarchiver that the filename is in UTF8
+      0b00000000000 | 0b100000000000
+    end
+
+    def write_local_file_header(io)
+      @local_file_header_location = io.tell # Save for the time when we need to write the central directory
+
+      # At this point if the header begins somewhere beyound 0xFFFFFFFF we _have_ to record the offset
+      # in the future as a zip64 extra field, so we give up, give in, you loose, love will always win...
+      @requires_zip64 = true if @local_file_header_location > FOUR_BYTE_MAX_UINT
+
+      io << [0x04034b50].pack('V')                        # local file header signature     4 bytes  (0x04034b50)
+
+      if @requires_zip64                                  # version needed to extract       2 bytes
+        io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack('v')
+      else
+        io << [VERSION_NEEDED_TO_EXTRACT].pack('v')
+      end
+
+      io << [gp_flags_based_on_filename].pack("v")        # general purpose bit flag        2 bytes
+      io << [storage_mode].pack("v")                      # compression method              2 bytes
+      io << [to_binary_dos_time(mtime)].pack('v')         # last mod file time              2 bytes
+      io << [to_binary_dos_date(mtime)].pack('v')         # last mod file date              2 bytes
+      io << [crc32].pack('V')                             # crc-32                          4 bytes
+
+      if @requires_zip64
+        io << [FOUR_BYTE_MAX_UINT].pack('V')              # compressed size              4 bytes
+        io << [FOUR_BYTE_MAX_UINT].pack('V')              # uncompressed size            4 bytes
+      else
+        io << [compressed_size].pack('V')                 # compressed size              4 bytes
+        io << [uncompressed_size].pack('V')               # uncompressed size            4 bytes
+      end
+
+      # Filename should not be longer than 0xFFFF otherwise this wont fit here
+      io << [filename.bytesize].pack('v')                 # file name length             2 bytes
+
+      if @requires_zip64
+        tmp = ''.force_encoding(Encoding::BINARY)
+        write_zip_64_extra_for_local_file_header(tmp)
+        io << [tmp.bytesize].pack('v')                    # extra field length              2 bytes
+      else
+        io << [0].pack('v')                               # extra field length              2 bytes
+      end
+
+      io << filename                                      # file name (variable size)
+
+      write_zip_64_extra_for_local_file_header(io) if @requires_zip64
+    end
+
+    def write_zip_64_extra_for_local_file_header(io)
+      io << [0x0001].pack('v')                        # 2 bytes    Tag for this "extra" block type
+      io << [16].pack('v')                            # 2 bytes    Size of this "extra" block. For us it will always be 16 (2x8)
+      io << [uncompressed_size].pack('Q<')            # 8 bytes    Original uncompressed file size
+      io << [compressed_size].pack('Q<')              # 8 bytes    Size of compressed data
+    end
+
+    def write_zip_64_extra_for_central_directory_file_header(io)
+      io << [0x0001].pack('v')                        # 2 bytes    Tag for this "extra" block type
+      io << [28].pack('v')                            # 2 bytes    Size of this "extra" block. For us it will always be 28
+      io << [uncompressed_size].pack('Q<')            # 8 bytes    Original uncompressed file size
+      io << [compressed_size].pack('Q<')              # 8 bytes    Size of compressed data
+      io << [@local_file_header_location].pack('Q<')  # 8 bytes    Offset of local header record
+      io << [0].pack('V')                             # 4 bytes    Number of the disk on which this file starts
+    end
+
+=begin
+    # I am keeping this for future use (if we want to generate ZIPs with postfix CRCs for instance)
+    def write_data_descriptor(io)
+      # 4.3.9.3 Although not originally assigned a signature, the value
+      #       0x08074b50 has commonly been adopted as a signature value
+      #       for the data descriptor record.
+      # 4.3.9.4 When writing ZIP files, implementors SHOULD include the
+      #    signature value marking the data descriptor record.  When
+      #    the signature is used, the fields currently defined for
+      #    the data descriptor record will immediately follow the
+      #    signature.
+      io << [0x08074b50].pack('V')
+      # 4.3.9.2 When compressing files, compressed and uncompressed sizes
+      # should be stored in ZIP64 format (as 8 byte values) when a
+      # file's size exceeds 0xFFFFFFFF.   However ZIP64 format may be
+      # used regardless of the size of a file.  When extracting, if
+      # the zip64 extended information extra field is present for
+      # the file the compressed and uncompressed sizes will be 8
+      # byte values.
+      io << [crc32].pack('V')                             # crc-32                          4 bytes
+      if @requires_zip64
+        io << [compressed_size].pack('Q<')                # compressed size                 8 bytes for ZIP64
+        io << [uncompressed_size].pack('Q<')              # uncompressed size               8 bytes for ZIP64
+      else
+        io << [compressed_size].pack('V')                 # compressed size                 4 bytes
+        io << [uncompressed_size].pack('V')               # uncompressed size               4 bytes
+      end
+    end
+=end
+
+    def write_central_directory_file_header(io)
+      io << [0x02014b50].pack('V')                        # central file header signature   4 bytes  (0x02014b50)
+
+      io << [VERSION_MADE_BY].pack('v')                   # version made by                 2 bytes
+      if @requires_zip64
+        io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack('v') # version needed to extract       2 bytes
+      else
+        io << [VERSION_NEEDED_TO_EXTRACT].pack('v')       # version needed to extract       2 bytes
+      end
+
+      io << [gp_flags_based_on_filename].pack('v')        # general purpose bit flag        2 bytes
+      io << [storage_mode].pack('v')                      # compression method              2 bytes
+      io << [to_binary_dos_time(mtime)].pack('v')         # last mod file time              2 bytes
+      io << [to_binary_dos_date(mtime)].pack('v')         # last mod file date              2 bytes
+      io << [crc32].pack('V')                             # crc-32                          4 bytes
+
+      if @requires_zip64
+        io << [FOUR_BYTE_MAX_UINT].pack('V')              # compressed size              4 bytes
+        io << [FOUR_BYTE_MAX_UINT].pack('V')              # uncompressed size            4 bytes
+      else
+        io << [compressed_size].pack('V')                 # compressed size              4 bytes
+        io << [uncompressed_size].pack('V')               # uncompressed size            4 bytes
+      end
+
+      # Filename should not be longer than 0xFFFF otherwise this wont fit here
+      io << [filename.bytesize].pack('v')                 # file name length                2 bytes
+
+      if @requires_zip64
+        local_fh_extra = ''.force_encoding(Encoding::BINARY)
+        write_zip_64_extra_for_central_directory_file_header(local_fh_extra)
+        io << [local_fh_extra.bytesize].pack('v')         # extra field length              2 bytes
+      else
+        io << [0].pack('v')                                 # extra field length              2 bytes
+      end
+
+      io << [0].pack('v')                                 # file comment length             2 bytes
+      io << [0].pack('v')                                 # disk number start               2 bytes
+      io << [0].pack('v')                                 # internal file attributes        2 bytes
+      io << [0].pack('V')                                 # external file attributes        4 bytes
+
+      if @requires_zip64
+        io << [FOUR_BYTE_MAX_UINT].pack('V')              # relative offset of local header 4 bytes
+      else
+        io << [@local_file_header_location].pack('V')     # relative offset of local header 4 bytes
+      end
+      io << filename                                      # file name (variable size)
+
+      if @requires_zip64                                  # extra field (variable size)
+        write_zip_64_extra_for_central_directory_file_header(io)
+      end
+                                                          # file comment (variable size)
+    end
+
+    private
+
+    def to_binary_dos_time(t)
+      (t.sec/2) + (t.min << 5) + (t.hour << 11)
+    end
+
+    def to_binary_dos_date(t)
+      (t.day) + (t.month << 5) + ((t.year - 1980) << 9)
+    end
+  end
+
+  # @param out_io[#<<, #tell] a writable object that responds to << and tell
+  def initialize(out_io)
+    @io = out_io
+    @files = []
+  end
+
+  def add_local_file_header(filename:, crc32:, compressed_size:, uncompressed_size:, storage_mode:, mtime: Time.now.utc)
+    if @files.any?{|e| e.filename == filename }
+      raise DuplicateFilenames, "Filename #{filename.inspect} already used in the archive"
+    end
+    raise UnknownMode, "Unknown compression mode #{storage_mode}" unless [STORED, DEFLATED].include?(storage_mode)
+    e = Entry.new(filename, crc32, compressed_size, uncompressed_size, storage_mode, mtime)
+    @files << e
+    e.write_local_file_header(@io)
+  end
+
+=begin
+  # Keeping for future use (if we want to write postfix CRCs for instance).
+  # The BOMArchiveHelper thing however is _really_ unhappy about those descriptors,
+  # and is likely to error out if you feed it one.
+  def write_data_descriptor
+    last_file = @files[-1]
+    raise "No files registered" unless last_file
+    last_file.write_data_descriptor(@io)
+  end
+=end
+
+  def write_central_directory
+    start_of_central_directory = @io.tell
+
+    # Central directory file headers, per file in order
+    @files.each do |file|
+      file.write_central_directory_file_header(@io)
+    end
+    central_dir_size = @io.tell - start_of_central_directory
+
+    zip64_required = central_dir_size > FOUR_BYTE_MAX_UINT ||
+      start_of_central_directory > FOUR_BYTE_MAX_UINT ||
+      @files.length > TWO_BYTE_MAX_UINT ||
+      @files.any?(&:requires_zip64?)
+
+    # Then, if zip64 is used
+    if zip64_required
+      # [zip64 end of central directory record]
+      zip64_eocdr_offset = @io.tell
+                                                # zip64 end of central dir
+      @io << [0x06064b50].pack('V')             # signature                       4 bytes  (0x06064b50)
+      @io << [44].pack('Q<')                    # size of zip64 end of central
+                                                # directory record                8 bytes
+                                                # (this is ex. the 12 bytes of the signature and the size value itself).
+                                                # Without the extensible data sector it is always 44.
+      @io << [VERSION_MADE_BY].pack('v')                      # version made by                 2 bytes
+      @io << [VERSION_NEEDED_TO_EXTRACT_ZIP64].pack('v')      # version needed to extract       2 bytes
+      @io << [0].pack('V')                                    # number of this disk             4 bytes
+      @io << [0].pack('V')                                    # number of the disk with the
+      @io                                                     # start of the central directory  4 bytes
+      @io << [@files.length].pack('Q<')                       # total number of entries in the
+      @io                                                     # central directory on this disk  8 bytes
+      @io << [@files.length].pack('Q<')                       # total number of entries in the
+      @io                                                     # central directory               8 bytes
+      @io << [central_dir_size].pack('Q<')                    # size of the central directory   8 bytes
+      @io                                                     # offset of start of central
+      @io                                                     # directory with respect to
+      @io << [start_of_central_directory].pack('Q<')          # the starting disk number        8 bytes
+                                                              # zip64 extensible data sector    (variable size)
+
+      # [zip64 end of central directory locator]
+      @io << [0x07064b50].pack("V")                           # zip64 end of central dir locator
+                                                              # signature                       4 bytes  (0x07064b50)
+      @io << [0].pack('V')                                    # number of the disk with the
+                                                              # start of the zip64 end of
+                                                              # central directory               4 bytes
+      @io << [zip64_eocdr_offset].pack('Q<')                  # relative offset of the zip64
+                                                              # end of central directory record 8 bytes
+      @io << [1].pack('V')                                    # total number of disks           4 bytes
+    end
+
+    # Then the end of central directory record:
+    @io << [0x06054b50].pack('V')                           # end of central dir signature     4 bytes  (0x06054b50)
+    @io << [0].pack('v')                                    # number of this disk              2 bytes
+    @io << [0].pack('v')                                    # number of the disk with the
+                                                            #   start of the central directory 2 bytes
+    @io << [@files.length].pack('v')                        # total number of entries in the
+                                                            # central directory on this disk   2 bytes
+    @io << [@files.length].pack('v')                        # total number of entries in
+                                                            # the central directory            2 bytes
+    if zip64_required
+      @io << [FOUR_BYTE_MAX_UINT].pack('V')                   # size of the central directory    4 bytes
+      @io << [FOUR_BYTE_MAX_UINT].pack('V')                   # offset of start of central
+                                                              # directory with respect to
+                                                              # the starting disk number        4 bytes
+    else
+      @io << [central_dir_size].pack('V')                     # size of the central directory    4 bytes
+      @io << [start_of_central_directory].pack('V')           # offset of start of central
+                                                              # directory with respect to
+                                                              # the starting disk number        4 bytes
+    end
+    @io << [0].pack('v')                                    # .ZIP file comment length        2 bytes
+                                                            # .ZIP file comment       (variable size)
+  end
+end

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -38,8 +38,10 @@ class ZipTricks::Streamer
   def initialize(stream)
     raise InvalidOutput, "The stream should respond to #<<" unless stream.respond_to?(:<<)
     stream = ZipTricks::WriteAndTell.new(stream) unless stream.respond_to?(:tell) && stream.respond_to?(:advance_position_by)
+    
     @output_stream = stream
-
+    @zip = ZipTricks::Microzip.new(@output_stream)
+    
     @state_monitor = VeryTinyStateMachine.new(:before_entry, callbacks_to=self)
     @state_monitor.permit_state :in_entry_header, :in_entry_body, :in_central_directory, :closed
     @state_monitor.permit_transition :before_entry => :in_entry_header
@@ -47,8 +49,6 @@ class ZipTricks::Streamer
     @state_monitor.permit_transition :in_entry_body => :in_entry_header
     @state_monitor.permit_transition :in_entry_body => :in_central_directory
     @state_monitor.permit_transition :in_central_directory => :closed
-
-    @entry_set = ::Zip::EntrySet.new
   end
 
   # Writes a part of a zip entry body (actual binary data of the entry) into the output stream.
@@ -99,16 +99,8 @@ class ZipTricks::Streamer
   # @return [Fixnum] the offset the output IO is at after writing the entry header
   def add_compressed_entry(entry_name, uncompressed_size, crc32, compressed_size)
     @state_monitor.transition! :in_entry_header
-
-    entry = ::Zip::Entry.new(@file_name, entry_name)
-    entry.compression_method = Zip::Entry::DEFLATED
-    entry.crc = crc32
-    entry.size = uncompressed_size
-    entry.compressed_size = compressed_size
-    set_gp_flags_for_filename(entry, entry_name)
-
-    @entry_set << entry
-    entry.write_local_entry(@output_stream)
+    @zip.add_local_file_header(filename: entry_name, crc32: crc32,
+      compressed_size: compressed_size, uncompressed_size: uncompressed_size, storage_mode: ZipTricks::Microzip::DEFLATED)
     @expected_bytes_for_entry = compressed_size
     @bytes_written_for_entry = 0
     @output_stream.tell
@@ -123,20 +115,12 @@ class ZipTricks::Streamer
   # @return [Fixnum] the offset the output IO is at after writing the entry header
   def add_stored_entry(entry_name, uncompressed_size, crc32)
     @state_monitor.transition! :in_entry_header
-
-    entry = ::Zip::Entry.new(@file_name, entry_name)
-    entry.compression_method = Zip::Entry::STORED
-    entry.crc = crc32
-    entry.size = uncompressed_size
-    entry.compressed_size = uncompressed_size
-    set_gp_flags_for_filename(entry, entry_name)
-    @entry_set << entry
-    entry.write_local_entry(@output_stream)
+    @zip.add_local_file_header(filename: entry_name, crc32: crc32,
+      compressed_size: uncompressed_size, uncompressed_size: uncompressed_size, storage_mode: ZipTricks::Microzip::STORED)
     @bytes_written_for_entry = 0
     @expected_bytes_for_entry = uncompressed_size
     @output_stream.tell
   end
-
 
   # Writes out the global footer and the directory entry header and the global directory of the ZIP
   # archive using the information about the entries added using `add_stored_entry` and `add_compressed_entry`.
@@ -146,8 +130,7 @@ class ZipTricks::Streamer
   # @return [Fixnum] the offset the output IO is at after writing the central directory
   def write_central_directory!
     @state_monitor.transition! :in_central_directory
-    cdir = Zip::CentralDirectory.new(@entry_set, comment = nil)
-    cdir.write_to_stream(@output_stream)
+    @zip.write_central_directory
     @output_stream.tell
   end
 
@@ -164,17 +147,6 @@ class ZipTricks::Streamer
   end
 
   private
-
-  # Set the general purpose flags for the entry. The only flag we care about is the EFS
-  # bit (bit 11) which should be set if the filename is UTF8. If it is, we need to set the
-  # bit so that the unarchiving application knows that the filename in the archive is UTF-8
-  # encoded, and not some DOS default. For ASCII entries it does not matter.
-  def set_gp_flags_for_filename(entry, filename)
-    filename.encode(Encoding::ASCII)
-    entry.gp_flags = DEFAULT_GP_FLAGS
-  rescue Encoding::UndefinedConversionError #=> UTF8 filename
-    entry.gp_flags = DEFAULT_GP_FLAGS | EFS
-  end
 
   # Checks whether the number of bytes written conforms to the declared entry size
   def leaving_in_entry_body_state

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,6 +78,21 @@ module ZipInspection
     escaped_cmd = Shellwords.join(['zipinfo', '-tlhvz', path_to_zip])
     $zip_inspection_buf.puts `#{escaped_cmd}`
   end
+  
+  def open_zip_with_osx_archive_utility(path_to_zip)
+    # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
+    # not perform any checks on the files since we do not really know where they are on disk.
+    # Visual inspection should show whether the unarchiving is handled correctly.
+    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/Contents/MacOS/Archive Utility'
+    `#{Shellwords.join([au_path, path_to_zip])}`
+  end
+  
+  def skip_if_system_does_not_have_archive_utility!
+    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/Contents/MacOS/Archive Utility'
+    unless File.exist?(au_path)
+      skip "This system does not have ArchiveUtility"
+    end
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,16 @@ class RandomFile < Tempfile
   end
 end
 
+module ZipInspection
+  def inspect_zip_with_external_tool(path_to_zip)
+    example_info = self.inspect # The only way to get at the RSpec example without using the block argument
+    $stderr.puts "Inspecting ZIP output of #{example_info}."
+    escaped_cmd = Shellwords.join(['zipinfo', '-tlhvz', path_to_zip])
+    $stderr.puts `#{escaped_cmd}`
+  end
+end
+
 RSpec.configure do |config|
   config.include Keepalive
+  config.include ZipInspection
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,22 +71,25 @@ end
 
 module ZipInspection
   def inspect_zip_with_external_tool(path_to_zip)
-    example_info = self.inspect # The only way to get at the RSpec example without using the block argument
+    zipinfo_path = 'zipinfo'
+    zipinfo_version = `#{zipinfo_path}`.split("\n").first
+    
     $zip_inspection_buf ||= StringIO.new
     $zip_inspection_buf.puts "\n"
-    $zip_inspection_buf.puts "Inspecting ZIP output of #{example_info}."
-    escaped_cmd = Shellwords.join(['zipinfo', '-tlhvz', path_to_zip])
+    $zip_inspection_buf.puts "Inspecting ZIP output of #{inspect}." # The only way to get at the RSpec example without using the block argument
+    $zip_inspection_buf.puts "Be aware that the zipinfo version on OSX is too old to deal with Zip6."
+    escaped_cmd = Shellwords.join([zipinfo_path, '-tlhvz', path_to_zip])
     $zip_inspection_buf.puts `#{escaped_cmd}`
   end
   
   def open_with_external_app(app_path, path_to_zip, skip_if_missing)
     bin_exists = File.exist?(app_path)
-    skip "This system does not have #{File.basename(app_path)}" if skip_if_missing && !bin_exists 
+    skip "This system does not have #{File.basename(app_path)}" if skip_if_missing && !bin_exists
     return unless bin_exists
     `#{Shellwords.join([app_path, path_to_zip])}`
   end
   
-  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: true)
+  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: false)
     # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
     # not perform any checks on the files since we do not really know where they are on disk.
     # Visual inspection should show whether the unarchiving is handled correctly.
@@ -94,7 +97,7 @@ module ZipInspection
     open_with_external_app(au_path, path_to_zip, skip_if_missing)
   end
   
-  def open_zip_with_unarchiver(path_to_zip, skip_if_missing: true)
+  def open_zip_with_unarchiver(path_to_zip, skip_if_missing: false)
     ua_path = '/Applications/The Unarchiver.app/Contents/MacOS/The Unarchiver'
     open_with_external_app(ua_path, path_to_zip, skip_if_missing)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,20 @@ require 'digest'
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
-RSpec.configure do |config|
+module Keepalive
+  # Travis-CI kills the build if it does not receive output on standard out or standard error
+  # for longer than a few minutes. We have a few tests that take a _very_ long time, and during
+  # those tests this method has to be called every now and then to revive the output and let the
+  # build proceed.
+  def still_alive!
+    @last_out_ping_at ||= Time.now
+    if (Time.now - @last_out_ping_at) > 3
+      @last_out_ping_at = Time.now
+      $stdout << '_'
+    end
+  end
+end
 
+RSpec.configure do |config|
+  config.include Keepalive
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,19 +79,24 @@ module ZipInspection
     $zip_inspection_buf.puts `#{escaped_cmd}`
   end
   
-  def open_zip_with_osx_archive_utility(path_to_zip)
+  def open_with_external_app(app_path, path_to_zip, skip_if_missing)
+    bin_exists = File.exist?(app_path)
+    skip "This system does not have #{File.basename(app_path)}" if skip_if_missing && !bin_exists 
+    return unless bin_exists
+    `#{Shellwords.join([app_path, path_to_zip])}`
+  end
+  
+  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: true)
     # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
     # not perform any checks on the files since we do not really know where they are on disk.
     # Visual inspection should show whether the unarchiving is handled correctly.
     au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/Contents/MacOS/Archive Utility'
-    `#{Shellwords.join([au_path, path_to_zip])}`
+    open_with_external_app(au_path, path_to_zip, skip_if_missing)
   end
   
-  def skip_if_system_does_not_have_archive_utility!
-    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/Contents/MacOS/Archive Utility'
-    unless File.exist?(au_path)
-      skip "This system does not have ArchiveUtility"
-    end
+  def open_zip_with_unarchiver(path_to_zip, skip_if_missing: true)
+    ua_path = '/Applications/The Unarchiver.app/Contents/MacOS/The Unarchiver'
+    open_with_external_app(ua_path, path_to_zip, skip_if_missing)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,12 +15,13 @@ module Keepalive
   # those tests this method has to be called every now and then to revive the output and let the
   # build proceed.
   def still_alive!
-    @last_out_ping_at ||= Time.now
-    if (Time.now - @last_out_ping_at) > 3
-      @last_out_ping_at = Time.now
+    $keepalive_last_out_ping_at ||= Time.now
+    if (Time.now - $keepalive_last_out_ping_at) > 3
+      $keepalive_last_out_ping_at = Time.now
       $stdout << '_'
     end
   end
+  extend self
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,13 +55,18 @@ end
 module ZipInspection
   def inspect_zip_with_external_tool(path_to_zip)
     example_info = self.inspect # The only way to get at the RSpec example without using the block argument
-    $stderr.puts "Inspecting ZIP output of #{example_info}."
+    $zip_inspection_buf ||= StringIO.new
+    $zip_inspection_buf.puts "\n"
+    $zip_inspection_buf.puts "Inspecting ZIP output of #{example_info}."
     escaped_cmd = Shellwords.join(['zipinfo', '-tlhvz', path_to_zip])
-    $stderr.puts `#{escaped_cmd}`
+    $zip_inspection_buf.puts `#{escaped_cmd}`
   end
 end
 
 RSpec.configure do |config|
   config.include Keepalive
   config.include ZipInspection
+  config.after :suite do
+    $stderr << $zip_inspection_buf.string if $zip_inspection_buf
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,8 +72,6 @@ end
 module ZipInspection
   def inspect_zip_with_external_tool(path_to_zip)
     zipinfo_path = 'zipinfo'
-    zipinfo_version = `#{zipinfo_path}`.split("\n").first
-    
     $zip_inspection_buf ||= StringIO.new
     $zip_inspection_buf.puts "\n"
     $zip_inspection_buf.puts "Inspecting ZIP output of #{inspect}." # The only way to get at the RSpec example without using the block argument

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -111,6 +111,8 @@ describe ZipTricks::Microzip do
       expect(the_entry.size).to eq(5 * 1024 * 1024 * 1024)
       expect(the_entry.extra_length).to be > 0
     end
+    
+    inspect_zip_with_external_tool(out_zip.path)
   end
 
   it 'creates an archive with 2 files each of which is just over 2GB (Zip64 due to offsets)', long: true do

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -146,7 +146,7 @@ describe ZipTricks::Microzip do
     inspect_zip_with_external_tool(out_zip.path)
   end
 
-  it 'creates an archive with more than 0xFFFF file entries (Zip64 due to number of files)', long: true do
+  it 'creates an archive with more than 65535 file entries (Zip64 due to number of files)', long: true do
     tf = ManagedTempfile.new('zip')
     z = described_class.new(tf)
 

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -3,9 +3,13 @@ require 'fileutils'
 require 'shellwords'
 
 describe ZipTricks::Microzip do
-  let(:test_text_file_path) {
-    File.join(__dir__, 'war-and-peace.txt')
-  }
+
+  class RandomFile < Tempfile
+    def initialize(size)
+      super('random-bin')
+
+    end
+  end
 
   # Run each test in a temporady directory, and nuke it afterwards
   around(:each) do |example|
@@ -21,7 +25,7 @@ describe ZipTricks::Microzip do
     yield.tap { ios.map(&:rewind) }
   end
 
-  it 'creates an archive with a number of very tiny text files' do
+  it 'creates an archive that can be opened by Rubyzip, with a small number of very tiny text files' do
     tf = Tempfile.new('zip')
     z = described_class.new(tf)
 
@@ -50,6 +54,15 @@ describe ZipTricks::Microzip do
       expect(entries.length).to eq(13)
     end
   end
+
+  xit 'raises an exception if the filename is non-unique in the already existing set'
+  it 'raises an exception if the filename does not fit in 0xFFFF bytes'
+  it 'correctly sets the general-purpose flag bit 11 when a UTF-8 filename is passed in'
+  it 'switches an entry to Zip64 if a file is added which, uncompreeed, is larger than the 4-byte max size'
+  it 'switches an entry to Zip64 if a file is added which, compressed, is larger than the 4-byte max size'
+  it 'switches an entry to Zip64 if a file is added which, compressed, is larger than the 4-byte max size'
+  it 'creates an archive with 1 5GB file (Zip64 due to a single file exceeding the size)', long: true
+  it 'creates an archive with 2 files each of which is just over 2GB (Zip64 due to offsets)', long: true
 
   it 'creates an archive with more than 0xFFFF file entries (Zip64 due to number of files)', long: true do
     tf = Tempfile.new('zip')

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -22,7 +22,7 @@ describe ZipTricks::Microzip do
     t = Time.now.utc
 
     3.times do |i|
-      fn = "test-#{i}.bin"
+      fn = "test-#{i}"
       z.add_local_file_header(filename: fn, crc32: crc, compressed_size: test_str.bytesize,
         uncompressed_size: test_str.bytesize, storage_mode: 0, mtime: t)
       tf << test_str

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -24,11 +24,11 @@ describe ZipTricks::Microzip do
   it 'creates an archive with a number of very tiny text files' do
     tf = Tempfile.new('zip')
     z = described_class.new(tf)
-    
+
     test_str = Random.new.bytes(64)
     crc = Zlib.crc32(test_str)
     t = Time.now.utc
-    
+
     13.times do |i|
       fn = "test-#{i}.bin"
       z.add_local_file_header(filename: fn, crc32: crc, compressed_size: test_str.bytesize,
@@ -37,9 +37,9 @@ describe ZipTricks::Microzip do
     end
     z.write_central_directory
     tf.flush
-    
-    entries = []
+
     Zip::File.open(tf.path) do |zip_file|
+      entries = []
       zip_file.each do |entry|
         entries << entry
         readback = entry.get_input_stream.read
@@ -48,6 +48,35 @@ describe ZipTricks::Microzip do
         expect(entry.name).to match(/test/)
       end
       expect(entries.length).to eq(13)
+    end
+  end
+
+  it 'creates an archive with more than 0xFFFF file entries (Zip64 due to number of files)' do
+    tf = Tempfile.new('zip')
+    z = described_class.new(tf)
+
+    test_str = Random.new.bytes(64)
+    crc = Zlib.crc32(test_str)
+    t = Time.now.utc
+
+    n_files = 0xFFFF + 6
+
+    n_files.times do |i|
+      fn = "test-#{i}.bin"
+      z.add_local_file_header(filename: fn, crc32: crc, compressed_size: test_str.bytesize,
+        uncompressed_size: test_str.bytesize, storage_mode: 0, mtime: t)
+      tf << test_str
+    end
+    z.write_central_directory
+    tf.flush
+
+    Zip::File.open(tf.path) do |zip_file|
+      entries = []
+      zip_file.each do |entry|
+        entries << entry
+        expect(entry.name).to match(/test/)
+      end
+      expect(entries.length).to eq(n_files)
     end
   end
 end

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -123,7 +123,7 @@ describe ZipTricks::Microzip do
     end
 
     inspect_zip_with_external_tool(out_zip.path)
-    open_zip_with_unarchiver_if_available(out_zip.path)
+    open_zip_with_unarchiver(out_zip.path)
   end
 
   it 'creates an archive with 2 files each of which is just over 2GB (Zip64 due to offsets)', long: true do
@@ -151,14 +151,16 @@ describe ZipTricks::Microzip do
       expect(entries.length).to eq(2)
       first_entry, second_entry = entries[0], entries[1]
 
-      expect(first_entry.extra_length).to be_zero # The file _itself_ is below 4GB
+      expect(first_entry.instance_variable_get("@extra_length")).to be_zero # The file _itself_ is below 4GB
       expect(first_entry.size).to eq(two_gigs_plus.size)
 
-      expect(second_entry.extra_length).to be_zero # The file _itself_ is below 4GB
+      expect(first_entry.instance_variable_get("@extra_length")).to be_zero # The file _itself_ is below 4GB
       expect(second_entry.size).to eq(two_gigs_plus.size)
     end
 
     inspect_zip_with_external_tool(out_zip.path)
+    open_zip_with_archive_utility(out_zip.path)
+    open_zip_with_unarchiver(out_zip.path)
   end
 
   it 'creates an archive with more than 65535 file entries (Zip64 due to number of files)', long: true do

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -41,7 +41,7 @@ describe ZipTricks::Microzip do
       end
       expect(entries.length).to eq(3)
     end
-    
+
     inspect_zip_with_external_tool(tf.path)
     open_zip_with_archive_utility(tf.path)
     open_zip_with_unarchiver(tf.path)
@@ -84,6 +84,8 @@ describe ZipTricks::Microzip do
       expect(the_entry.gp_flags).to eq(2048)
       expect(the_entry.name.force_encoding(Encoding::UTF_8)).to match(/тест/)
     end
+    open_zip_with_archive_utility(out_zip.path)
+    open_zip_with_unarchiver(out_zip.path)
   end
 
   it 'creates an archive with 1 5GB file (Zip64 due to a single file exceeding the size)', long: true do
@@ -109,7 +111,7 @@ describe ZipTricks::Microzip do
       expect(the_entry.size).to eq(5 * 1024 * 1024 * 1024)
       expect(the_entry.instance_variable_get("@extra_length")).to be > 0 # Not accessible publicly
     end
-    
+
     inspect_zip_with_external_tool(out_zip.path)
     open_zip_with_unarchiver_if_available(out_zip.path)
   end
@@ -138,10 +140,10 @@ describe ZipTricks::Microzip do
       end
       expect(entries.length).to eq(2)
       first_entry, second_entry = entries[0], entries[1]
-      
+
       expect(first_entry.extra_length).to be_zero # The file _itself_ is below 4GB
       expect(first_entry.size).to eq(two_gigs_plus.size)
-      
+
       expect(second_entry.extra_length).to be_zero # The file _itself_ is below 4GB
       expect(second_entry.size).to eq(two_gigs_plus.size)
     end

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -34,18 +34,21 @@ describe ZipTricks::Microzip do
       entries = []
       zip_file.each do |entry|
         entries << entry
-        
+
+        # Make sure it is tagged as UNIX
+        expect(entry.fstype).to eq(3)
+
         # Check the file contents
         readback = entry.get_input_stream.read
         readback.force_encoding(Encoding::BINARY)
         expect(readback).to eq(test_str)
-        
+
         # The CRC
         expect(entry.crc).to eq(crc)
-        
+
         # Check the name
         expect(entry.name).to match(/test/)
-        
+
         # Check the right external attributes (non-executable on UNIX)
         expect(entry.external_file_attributes).to eq(2175008768)
       end

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -34,10 +34,20 @@ describe ZipTricks::Microzip do
       entries = []
       zip_file.each do |entry|
         entries << entry
+        
+        # Check the file contents
         readback = entry.get_input_stream.read
         readback.force_encoding(Encoding::BINARY)
         expect(readback).to eq(test_str)
+        
+        # The CRC
+        expect(entry.crc).to eq(crc)
+        
+        # Check the name
         expect(entry.name).to match(/test/)
+        
+        # Check the right external attributes (non-executable on UNIX)
+        expect(entry.external_file_attributes).to eq(2175008768)
       end
       expect(entries.length).to eq(3)
     end

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -51,7 +51,7 @@ describe ZipTricks::Microzip do
     end
   end
 
-  it 'creates an archive with more than 0xFFFF file entries (Zip64 due to number of files)' do
+  it 'creates an archive with more than 0xFFFF file entries (Zip64 due to number of files)', long: true do
     tf = Tempfile.new('zip')
     z = described_class.new(tf)
 

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -176,7 +176,8 @@ describe ZipTricks::Microzip do
 
     # TODO: unzip in OSX is too old to cope
     output = `unzip -v #{out_zip.path}`
-    $stderr.puts output.inspect
+    $stderr.puts "Result of running unzip on the result of example ...:"
+    $stderr.puts output
   end
 
   it 'creates an archive with more than 0xFFFF file entries (Zip64 due to number of files)', long: true do

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -43,6 +43,8 @@ describe ZipTricks::Microzip do
     end
     
     inspect_zip_with_external_tool(tf.path)
+    open_zip_with_archive_utility(tf.path)
+    open_zip_with_unarchiver(tf.path)
   end
 
   it 'raises an exception if the filename is non-unique in the already existing set' do
@@ -109,6 +111,7 @@ describe ZipTricks::Microzip do
     end
     
     inspect_zip_with_external_tool(out_zip.path)
+    open_zip_with_unarchiver_if_available(out_zip.path)
   end
 
   it 'creates an archive with 2 files each of which is just over 2GB (Zip64 due to offsets)', long: true do

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -31,10 +31,9 @@ describe ZipTricks::Microzip do
     tf.flush
 
     Zip::File.open(tf.path) do |zip_file|
-      entries = []
-      zip_file.each do |entry|
-        entries << entry
-
+      entries = zip_file.to_a
+      expect(entries.length).to eq(3)
+      entries.each do |entry|
         # Make sure it is tagged as UNIX
         expect(entry.fstype).to eq(3)
 
@@ -52,7 +51,6 @@ describe ZipTricks::Microzip do
         # Check the right external attributes (non-executable on UNIX)
         expect(entry.external_file_attributes).to eq(2175008768)
       end
-      expect(entries.length).to eq(3)
     end
 
     inspect_zip_with_external_tool(tf.path)

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -45,6 +45,8 @@ describe ZipTricks::Microzip do
       end
       expect(entries.length).to eq(13)
     end
+    
+    inspect_zip_with_external_tool(tf.path)
   end
 
   it 'raises an exception if the filename is non-unique in the already existing set' do
@@ -143,10 +145,7 @@ describe ZipTricks::Microzip do
       expect(second_entry.size).to eq(two_gigs_plus.size)
     end
 
-    # TODO: unzip in OSX is too old to cope
-    output = `unzip -v #{out_zip.path}`
-    $stderr.puts "Result of running unzip on the result of example ...:"
-    $stderr.puts output
+    inspect_zip_with_external_tool(out_zip.path)
   end
 
   it 'creates an archive with more than 0xFFFF file entries (Zip64 due to number of files)', long: true do

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -7,12 +7,14 @@ describe ZipTricks::Microzip do
     attr_reader :crc32
     def initialize(size)
       super('random-bin')
+      binmode
       crc = ZipTricks::StreamCRC32.new
       
       random = Random.new
       bytes = size % (1024 * 1024)
       megs = size / (1024 * 1024)
       megs.times do
+        Keepalive.still_alive!
         random_blob = random.bytes(1024 * 1024)
         self << random_blob
         crc << random_blob
@@ -21,6 +23,7 @@ describe ZipTricks::Microzip do
       self << random_blob
       crc << random_blob
       @crc32 = crc.to_i
+      rewind
     end
   end
 
@@ -68,13 +71,70 @@ describe ZipTricks::Microzip do
     end
   end
 
-  xit 'raises an exception if the filename is non-unique in the already existing set'
-  it 'raises an exception if the filename does not fit in 0xFFFF bytes'
-  it 'correctly sets the general-purpose flag bit 11 when a UTF-8 filename is passed in'
-  it 'switches an entry to Zip64 if a file is added which, uncompreeed, is larger than the 4-byte max size'
-  it 'switches an entry to Zip64 if a file is added which, compressed, is larger than the 4-byte max size'
-  it 'switches an entry to Zip64 if a file is added which, compressed, is larger than the 4-byte max size'
-  it 'creates an archive with 1 5GB file (Zip64 due to a single file exceeding the size)', long: true
+  it 'raises an exception if the filename is non-unique in the already existing set' do
+    z = described_class.new(StringIO.new)
+    z.add_local_file_header(filename: 'foo.txt', crc32: 0, compressed_size: 0, uncompressed_size: 0, storage_mode: 0)
+    expect {
+      z.add_local_file_header(filename: 'foo.txt', crc32: 0, compressed_size: 0, uncompressed_size: 0, storage_mode: 0)
+    }.to raise_error(/already/)
+  end
+  
+  it 'raises an exception if the filename does not fit in 0xFFFF bytes' do
+    longest_filename_in_the_universe = "x" * (0xFFFF + 1)
+    z = described_class.new(StringIO.new)
+    expect {
+      z.add_local_file_header(filename: longest_filename_in_the_universe, crc32: 0, compressed_size: 0, uncompressed_size: 0, storage_mode: 0)
+    }.to raise_error(/filename/)
+  end
+  
+  it 'correctly sets the general-purpose flag bit 11 when a UTF-8 filename is passed in' do
+    the_f = RandomFile.new(19)
+    
+    out_zip = Tempfile.new('zip')
+    z = described_class.new(out_zip)
+    z.add_local_file_header(filename: 'тест', crc32: the_f.crc32, compressed_size: the_f.size,
+      uncompressed_size: the_f.size, storage_mode: 0, mtime: Time.now)
+    IO.copy_stream(the_f, out_zip)
+    z.write_central_directory
+    out_zip.flush
+    
+    Zip::File.open(out_zip.path) do |zip_file|
+      entries = []
+      zip_file.each do |entry|
+        entries << entry
+      end
+      the_entry = entries[0]
+      
+      expect(the_entry.gp_flags).to eq(2048)
+      expect(the_entry.name.force_encoding(Encoding::UTF_8)).to match(/тест/)
+    end
+  end
+  
+  it 'creates an archive with 1 5GB file (Zip64 due to a single file exceeding the size)', long: true do
+    five_gigs = RandomFile.new(5 * 1024 * 1024 * 1024)
+    
+    out_zip = Tempfile.new('huge-zip')
+    z = described_class.new(out_zip)
+    z.add_local_file_header(filename: 'the-five-gigs', crc32: five_gigs.crc32, compressed_size: five_gigs.size,
+      uncompressed_size: five_gigs.size, storage_mode: 0, mtime: Time.now)
+    IO.copy_stream(five_gigs, out_zip)
+    z.write_central_directory
+    out_zip.flush
+    
+    Zip::File.open(out_zip.path) do |zip_file|
+      entries = []
+      zip_file.each do |entry|
+        entries << entry
+        expect(entry.name).to match(/five/)
+      end
+      the_entry = entries[0]
+      expect(the_entry.version_needed_to_extract).to eq(45)
+      expect(the_entry.compressed_size).to eq(5 * 1024 * 1024 * 1024)
+      expect(the_entry.size).to eq(5 * 1024 * 1024 * 1024)
+      expect(the_entry.extra_length).to be > 0
+    end
+  end
+  
   it 'creates an archive with 2 files each of which is just over 2GB (Zip64 due to offsets)', long: true
 
   it 'creates an archive with more than 0xFFFF file entries (Zip64 due to number of files)', long: true do

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -1,0 +1,53 @@
+require_relative '../spec_helper'
+require 'fileutils'
+require 'shellwords'
+
+describe ZipTricks::Microzip do
+  let(:test_text_file_path) {
+    File.join(__dir__, 'war-and-peace.txt')
+  }
+
+  # Run each test in a temporady directory, and nuke it afterwards
+  around(:each) do |example|
+    wd = Dir.pwd
+    Dir.mktmpdir do | td |
+      Dir.chdir(td)
+      example.run
+    end
+    Dir.chdir(wd)
+  end
+
+  def rewind_after(*ios)
+    yield.tap { ios.map(&:rewind) }
+  end
+
+  it 'creates an archive with a number of very tiny text files' do
+    tf = Tempfile.new('zip')
+    z = described_class.new(tf)
+    
+    test_str = Random.new.bytes(64)
+    crc = Zlib.crc32(test_str)
+    t = Time.now.utc
+    
+    13.times do |i|
+      fn = "test-#{i}.bin"
+      z.add_local_file_header(filename: fn, crc32: crc, compressed_size: test_str.bytesize,
+        uncompressed_size: test_str.bytesize, storage_mode: 0, mtime: t)
+      tf << test_str
+    end
+    z.write_central_directory
+    tf.flush
+    
+    entries = []
+    Zip::File.open(tf.path) do |zip_file|
+      zip_file.each do |entry|
+        entries << entry
+        readback = entry.get_input_stream.read
+        readback.force_encoding(Encoding::BINARY)
+        expect(readback).to eq(test_str)
+        expect(entry.name).to match(/test/)
+      end
+      expect(entries.length).to eq(13)
+    end
+  end
+end

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -13,10 +13,6 @@ describe ZipTricks::Microzip do
     Dir.chdir(wd)
   end
 
-  def rewind_after(*ios)
-    yield.tap { ios.map(&:rewind) }
-  end
-
   it 'creates an archive that can be opened by Rubyzip, with a small number of very tiny text files' do
     tf = ManagedTempfile.new('zip')
     z = described_class.new(tf)

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -3,37 +3,6 @@ require 'fileutils'
 require 'shellwords'
 
 describe ZipTricks::Microzip do
-  class RandomFile < Tempfile
-    attr_reader :crc32
-    RANDOM_MEG = Random.new.bytes(1024 * 1024)
-    def initialize(size)
-      super('random-bin')
-      binmode
-      crc = ZipTricks::StreamCRC32.new
-      bytes = size % (1024 * 1024)
-      megs = size / (1024 * 1024)
-      megs.times do
-        Keepalive.still_alive!
-        self << RANDOM_MEG
-        crc << RANDOM_MEG
-      end
-      random_blob = Random.new.bytes(bytes)
-      self << random_blob
-      crc << random_blob
-      @crc32 = crc.to_i
-      rewind
-    end
-
-    def copy_to(io)
-      rewind
-      while data = read(10*1024*1024)
-        io << data
-        Keepalive.still_alive!
-      end
-      rewind
-    end
-  end
-
   # Run each test in a temporady directory, and nuke it afterwards
   around(:each) do |example|
     wd = Dir.pwd

--- a/spec/zip_tricks/remote_io_spec.rb
+++ b/spec/zip_tricks/remote_io_spec.rb
@@ -80,7 +80,9 @@ describe ZipTricks::RemoteIO do
     end
 
     after :each do
-      @buf.close; @buf.unlink
+      if @buf
+        @buf.close; @buf.unlink
+      end
     end
 
     context 'without arguments' do

--- a/spec/zip_tricks/stored_size_estimator_spec.rb
+++ b/spec/zip_tricks/stored_size_estimator_spec.rb
@@ -13,10 +13,10 @@ describe ZipTricks::StoredSizeEstimator do
 
       estimator.add_stored_entry("second-file.bin", raw_file_2.size)
 
-      r = estimator.add_compressed_entry("second-file.bin", raw_file_2.size, raw_file_3.size)
+      r = estimator.add_compressed_entry("second-flie.bin", raw_file_2.size, raw_file_3.size)
       expect(r).to eq(estimator), "add_compressed_entry should return self"
     end
 
-    expect(predicted_size).to eq(1410524)
+    expect(predicted_size).to eq(1410585)
   end
 end

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -125,7 +125,8 @@ describe ZipTricks::Streamer do
       File.unlink('test.zip') rescue nil
       File.rename(outbuf.path, 'osx-archive-test.zip')
       
-      open_zip_with_archive_utility('osx-archive-test.zip')
+      # Mark this test as skipped if the system does not have the binary
+      open_zip_with_archive_utility('osx-archive-test.zip', skip_if_missing: true)
     end
     FileUtils.rm_rf('osx-archive-test')
     FileUtils.rm_rf('osx-archive-test.zip')

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -94,11 +94,8 @@ describe ZipTricks::Streamer do
   end
 
   it 'creates an archive that OSX ArchiveUtility can handle' do
-    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/Contents/MacOS/Archive Utility'
-    unless File.exist?(au_path)
-      skip "This system does not have ArchiveUtility"
-    end
-
+    skip_if_system_does_not_have_archive_utility!
+    
     outbuf = Tempfile.new('zip')
     outbuf.binmode
 
@@ -129,11 +126,8 @@ describe ZipTricks::Streamer do
       outbuf.flush
       File.unlink('test.zip') rescue nil
       File.rename(outbuf.path, 'osx-archive-test.zip')
-
-      # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
-      # not perform any checks on the files since we do not really know where they are on disk.
-      # Visual inspection should show whether the unarchiving is handled correctly.
-      `#{Shellwords.join([au_path, 'osx-archive-test.zip'])}`
+      
+      open_zip_with_osx_archive_utility('osx-archive-test.zip')
     end
 
     FileUtils.rm_rf('osx-archive-test')

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -94,8 +94,6 @@ describe ZipTricks::Streamer do
   end
 
   it 'creates an archive that OSX ArchiveUtility can handle' do
-    skip_if_system_does_not_have_archive_utility!
-    
     outbuf = Tempfile.new('zip')
     outbuf.binmode
 

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -125,7 +125,7 @@ describe ZipTricks::Streamer do
       File.unlink('test.zip') rescue nil
       File.rename(outbuf.path, 'osx-archive-test.zip')
       
-      open_zip_with_osx_archive_utility('osx-archive-test.zip')
+      open_zip_with_archive_utility('osx-archive-test.zip')
     end
 
     FileUtils.rm_rf('osx-archive-test')

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -127,7 +127,6 @@ describe ZipTricks::Streamer do
       
       open_zip_with_archive_utility('osx-archive-test.zip')
     end
-
     FileUtils.rm_rf('osx-archive-test')
     FileUtils.rm_rf('osx-archive-test.zip')
   end

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -45,7 +45,7 @@ describe ZipTricks::Streamer do
 
     pos = zip.write_central_directory!
     expect(pos).to eq(io.tell)
-    expect(pos).to eq(17985)
+    expect(pos).to eq(18039)
 
     pos_after_close = zip.close
     expect(pos_after_close).to eq(pos)

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -90,10 +90,8 @@ describe ZipTricks::Streamer do
     expect(per_filename['compressed-file.bin'].bytesize).to eq(f.size)
     expect(Digest::SHA1.hexdigest(per_filename['compressed-file.bin'])).to eq(Digest::SHA1.hexdigest(f.read))
 
-    output = `unzip -v #{zip_file.path}`
-    puts output.inspect
+    inspect_zip_with_external_tool(zip_file.path)
   end
-
 
   it 'creates an archive that OSX ArchiveUtility can handle' do
     au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/Contents/MacOS/Archive Utility'
@@ -188,8 +186,7 @@ describe ZipTricks::Streamer do
     wd = Dir.pwd
     Dir.mktmpdir do | td |
       Dir.chdir(td)
-      output = `unzip -v #{zip_buf.path}`
-      puts output.inspect
+      inspect_zip_with_external_tool(zip_buf.path)
     end
     Dir.chdir(wd)
   end

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -38,7 +38,7 @@ describe ZipTricks::Streamer do
     expect(retval).to eq(zip)
     expect(io.tell).to eq(8950)
 
-    pos = zip.add_stored_entry('file.jpg', 8921, 182919)
+    pos = zip.add_stored_entry('filf.jpg', 8921, 182919)
     expect(pos).to eq(8988)
     zip << SecureRandom.random_bytes(8921)
     expect(io.tell).to eq(17909)


### PR DESCRIPTION
We are having issues with Zip64 support in Rubyzip. Pointers indicate that it has to do with their use of `Zip64Placeholder` extra field to substitute the Zip64 information in the local file headers. We cannot rewind the output, and these Zip64Placeholder extra fields remain in the written file.

Also RubyZip is, because of all it's extensibility, rather Java-esque and is "ravioli code" - everything is packaged in very small, neat boxes but when you need to figure out what is happening when you are actually writing a file it becomes very hard to analyse. Therefore I have decided to replace the actual zip writing implementation with our own, to have the following benefits:

* See what is happening, on one page of code
* Have control over what gets written
* Make maximum use of our advantages (we have non-rewindable output, _but_ we know the CRC32 and all the file sizes upfront)

## Checklist for the implementation:

- [x] Write standard ZIPs (below Zip64 thresholds)
- [x] Write Zip64 files when any file is larger than 4GB
- [x] Write Zip64 files when the data blocks for all the files + all the local file headers exceed 4GB in size
- [x] Write Zip64 extra fields upfront if they are required _per entry_
- [x] Write files with Unix file type ("version made by") settings and make them non-executable upon extraction
- [x] Write Zip64 if the number of files in the archive exceeds 0xFFFF

## Operational points (interop tests):

- [x] Tag all Zip64 cases as "long" examples so that they can be skipped
- [ ] Arrange larger disk space for containers that run our Travis builds (we need about 15GB of disk to run through all the tests successfully)
- [x] Add automatic tests for Zip64 large archive cases
- [ ] Verify behavior of various unarchive tools with regards to the EFS (extended language support) general purpose flags bit. The big tells the unarchiving software that the file name is encoded in UTF-8

## Operational points (unit tests):

- [ ] Add tests with Zip64 that use a mock IO with fake offsets, to not have to write large files. These will run just fine on Travis-CI.

## Compatibility testing matrix

We need to test with the builtin OSX unarchive tool and The Unarchiver, on Windows we need to test the _builtin unzip tool_ and _7Zip 9.20_. Other tools may be tested but they are not our recommendation, and as such do not have priority.


## Optimization points as icing on the cake (potential)

- [ ] Consolidate all the uses of `[something].pack(specifier)` into a method
- [ ] Benchmark heap contention due to the allocation of lots of temporary Arrray objects for packing, and if necessary, reuse one single Array