### PR TITLE
WIP: Optional use of data descriptors (postfix ZIPs)

### DIFF
--- a/lib/zip_tricks/compressing_streamer.rb
+++ b/lib/zip_tricks/compressing_streamer.rb
@@ -1,0 +1,97 @@
+class ZipTricks::CompressingStreamer
+  class StoredWriter
+    attr_reader :compressed_size, :uncompressed_size
+    def initialize(io)
+      @io = io
+      @uncompressed_size = 0
+      @compressed_size = 0
+      @started_at = io.tell
+      @crc = ZipTricks::StreamCRC32.new
+    end
+    
+    def crc32
+      @crc.to_i
+    end
+    
+    def <<(data)
+      @uncompressed_size += data.bytesize
+      @io << data
+      @crc << data
+      self
+    end
+    
+    def write(data)
+      self << data
+      data.bytesize
+    end
+    
+    def finish
+      @compressed_size = @uncompressed_size
+    end
+  end
+  
+  class DeflatedWriter
+    attr_reader :compressed_size, :uncompressed_size
+    def initialize(io)
+      @io = io
+      @uncompressed_size = 0
+      @compressed_size = 0
+      @started_at = io.tell
+      @crc = ZipTricks::StreamCRC32.new
+    end
+    
+    def crc32
+      @crc.to_i
+    end
+    
+    def <<(data)
+      @uncompressed_size += data.bytesize
+      @io << ZipTricks::BlockDeflate.deflate_chunk(data)
+      @crc << data
+      self
+    end
+    
+    def write(data)
+      self << data
+      data.bytesize
+    end
+    
+    def finish
+      ZipTricks::BlockDeflate.write_terminator(@io)
+      @compressed_size = @io.tell - @started_at
+    end
+  end
+  
+  def initialize(out)
+    @io = out
+    @zip = ZipTricks::Microzip.new
+  end
+  
+  def add_file_stored(filename)
+    @zip.add_local_file_header_of_unknown_size(io: @io, filename: filename, storage_mode: 0)
+    w = StoredWriter.new(@io)
+    yield(w)
+    w.finish
+    @zip.write_data_descriptor(io: @io, crc32: w.crc32, compressed_size: w.compressed_size,
+      uncompressed_size: w.uncompressed_size)
+  end
+  
+  def add_file_deflated(filename)
+    @zip.add_local_file_header_of_unknown_size(io: @io, filename: filename, storage_mode: 8)
+    w = DeflatedWriter.new(@io)
+    yield(w)
+    w.finish
+    @zip.write_data_descriptor(io: @io, crc32: w.crc32, compressed_size: w.compressed_size,
+      uncompressed_size: w.uncompressed_size)
+  end
+  
+  def close
+    @zip.write_central_directory(@io)
+  end
+  
+  def self.open(io)
+    me = new(io)
+    yield(me)
+    me.close
+  end
+end

--- a/lib/zip_tricks/compressing_streamer.rb
+++ b/lib/zip_tricks/compressing_streamer.rb
@@ -1,6 +1,5 @@
 class ZipTricks::CompressingStreamer
   class StoredWriter
-    attr_reader :compressed_size, :uncompressed_size
     def initialize(io)
       @io = io
       @uncompressed_size = 0
@@ -8,88 +7,77 @@ class ZipTricks::CompressingStreamer
       @started_at = io.tell
       @crc = ZipTricks::StreamCRC32.new
     end
-    
-    def crc32
-      @crc.to_i
-    end
-    
+
     def <<(data)
-      @uncompressed_size += data.bytesize
       @io << data
       @crc << data
       self
     end
-    
+
     def write(data)
       self << data
       data.bytesize
     end
-    
+
     def finish
-      @compressed_size = @uncompressed_size
+      size = @io.tell - @started_at
+      [@crc.to_i, size, size]
     end
   end
-  
+
   class DeflatedWriter
-    attr_reader :compressed_size, :uncompressed_size
     def initialize(io)
       @io = io
       @uncompressed_size = 0
-      @compressed_size = 0
       @started_at = @io.tell
       @crc = ZipTricks::StreamCRC32.new
       self << '' # Start the deflate stream correctly
     end
-    
-    def crc32
-      @crc.to_i
-    end
-    
+
     def <<(data)
       @uncompressed_size += data.bytesize
       @io << ZipTricks::BlockDeflate.deflate_chunk(data)
       @crc << data
       self
     end
-    
+
     def write(data)
       self << data
       data.bytesize
     end
-    
+
     def finish
       ZipTricks::BlockDeflate.write_terminator(@io)
-      @compressed_size = @io.tell - @started_at
+      [@crc.to_i, @io.tell - @started_at, @uncompressed_size]
     end
   end
-  
+
   def initialize(out)
     @io = out
     @zip = ZipTricks::Microzip.new
   end
-  
+
   def write_stored_file(filename)
     @zip.add_local_file_header_of_unknown_size(io: @io, filename: filename, storage_mode: 0)
     w = StoredWriter.new(@io)
     yield(w)
     w.finish
-    @zip.write_data_descriptor(io: @io, crc32: w.crc32, compressed_size: w.compressed_size,
-      uncompressed_size: w.uncompressed_size)
+    crc, comp, uncomp = w.finish
+    @zip.write_data_descriptor(io: @io, crc32: crc, compressed_size: comp, uncompressed_size: uncomp)
   end
-  
+
   def write_deflated_file(filename)
     @zip.add_local_file_header_of_unknown_size(io: @io, filename: filename, storage_mode: 8)
     w = DeflatedWriter.new(@io)
     yield(w)
-    w.finish
-    @zip.write_data_descriptor(io: @io, crc32: w.crc32, compressed_size: w.compressed_size,
-      uncompressed_size: w.uncompressed_size)
+    crc, comp, uncomp = w.finish
+    @zip.write_data_descriptor(io: @io, crc32: crc, compressed_size: comp, uncompressed_size: uncomp)
   end
-  
+
   def close
     @zip.write_central_directory(@io)
   end
-  
+
   def self.open(io)
     me = new(io)
     yield(me)

--- a/lib/zip_tricks/compressing_streamer.rb
+++ b/lib/zip_tricks/compressing_streamer.rb
@@ -31,7 +31,6 @@ class ZipTricks::CompressingStreamer
       @uncompressed_size = 0
       @started_at = @io.tell
       @crc = ZipTricks::StreamCRC32.new
-      self << '' # Start the deflate stream correctly
     end
 
     def <<(data)

--- a/lib/zip_tricks/compressing_streamer.rb
+++ b/lib/zip_tricks/compressing_streamer.rb
@@ -38,6 +38,7 @@ class ZipTricks::CompressingStreamer
       @compressed_size = 0
       @started_at = @io.tell
       @crc = ZipTricks::StreamCRC32.new
+      self << '' # Start the deflate stream correctly
     end
     
     def crc32
@@ -67,7 +68,7 @@ class ZipTricks::CompressingStreamer
     @zip = ZipTricks::Microzip.new
   end
   
-  def add_file_stored(filename)
+  def write_stored_file(filename)
     @zip.add_local_file_header_of_unknown_size(io: @io, filename: filename, storage_mode: 0)
     w = StoredWriter.new(@io)
     yield(w)
@@ -76,7 +77,7 @@ class ZipTricks::CompressingStreamer
       uncompressed_size: w.uncompressed_size)
   end
   
-  def add_file_deflated(filename)
+  def write_deflated_file(filename)
     @zip.add_local_file_header_of_unknown_size(io: @io, filename: filename, storage_mode: 8)
     w = DeflatedWriter.new(@io)
     yield(w)

--- a/lib/zip_tricks/compressing_streamer.rb
+++ b/lib/zip_tricks/compressing_streamer.rb
@@ -36,7 +36,7 @@ class ZipTricks::CompressingStreamer
       @io = io
       @uncompressed_size = 0
       @compressed_size = 0
-      @started_at = io.tell
+      @started_at = @io.tell
       @crc = ZipTricks::StreamCRC32.new
     end
     

--- a/spec/zip_tricks/compressing_streamer_spec.rb
+++ b/spec/zip_tricks/compressing_streamer_spec.rb
@@ -5,10 +5,10 @@ describe ZipTricks::CompressingStreamer do
   it 'creates an archive that can be opened by Rubyzip, with a small number of very tiny text files' do
     tf = ManagedTempfile.new('zip')
     z = described_class.open(tf) do |zip|
-      zip.add_file_deflated('defl.bin') do |sink|
+      zip.write_deflated_file('defl.bin') do |sink|
         sink << File.read(__dir__ + '/war-and-peace.txt')
       end
-      zip.add_file_stored('stor.bin') do |sink|
+      zip.write_stored_file('stor.bin') do |sink|
         sink << File.read(__dir__ + '/war-and-peace.txt')
       end
     end

--- a/spec/zip_tricks/compressing_streamer_spec.rb
+++ b/spec/zip_tricks/compressing_streamer_spec.rb
@@ -22,19 +22,19 @@ describe ZipTricks::CompressingStreamer do
         # Make sure it is tagged as UNIX
         expect(entry.fstype).to eq(3)
 
+         # The CRC
+        expect(entry.crc).to eq(Zlib.crc32(File.read(__dir__ + '/war-and-peace.txt')))
+
+        # Check the name
+        expect(entry.name).to match(/\.bin$/)
+
+        # Check the right external attributes (non-executable on UNIX)
+        expect(entry.external_file_attributes).to eq(2175008768)
+        
         # Check the file contents
         readback = entry.get_input_stream.read
         readback.force_encoding(Encoding::BINARY)
         expect(readback[0..10]).to eq(File.read(__dir__ + '/war-and-peace.txt')[0..10])
-
-        # The CRC
-        expect(entry.crc).to eq(crc)
-
-        # Check the name
-        expect(entry.name).to match(/test/)
-
-        # Check the right external attributes (non-executable on UNIX)
-        expect(entry.external_file_attributes).to eq(2175008768)
       end
     end
 

--- a/spec/zip_tricks/compressing_streamer_spec.rb
+++ b/spec/zip_tricks/compressing_streamer_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../spec_helper'
+
+describe ZipTricks::CompressingStreamer do
+  
+  it 'creates an archive that can be opened by Rubyzip, with a small number of very tiny text files' do
+    tf = ManagedTempfile.new('zip')
+    z = described_class.open(tf) do |zip|
+      zip.add_file_deflated('defl.bin') do |sink|
+        sink << File.read(__dir__ + '/war-and-peace.txt')
+      end
+      zip.add_file_stored('stor.bin') do |sink|
+        sink << File.read(__dir__ + '/war-and-peace.txt')
+      end
+    end
+    tf.flush
+    
+    Zip::File.open(tf.path) do |zip_file|
+      entries = zip_file.to_a
+      expect(entries.length).to eq(2)
+      entries.each_with_index do |entry, i|
+        $stderr.puts("Decoding #{i}")
+        # Make sure it is tagged as UNIX
+        expect(entry.fstype).to eq(3)
+
+        # Check the file contents
+        readback = entry.get_input_stream.read
+        readback.force_encoding(Encoding::BINARY)
+        expect(readback[0..10]).to eq(File.read(__dir__ + '/war-and-peace.txt')[0..10])
+
+        # The CRC
+        expect(entry.crc).to eq(crc)
+
+        # Check the name
+        expect(entry.name).to match(/test/)
+
+        # Check the right external attributes (non-executable on UNIX)
+        expect(entry.external_file_attributes).to eq(2175008768)
+      end
+    end
+
+    inspect_zip_with_external_tool(tf.path)
+  end
+end

--- a/spec/zip_tricks/microzip_interop_spec.rb
+++ b/spec/zip_tricks/microzip_interop_spec.rb
@@ -45,4 +45,47 @@ describe 'Microzip in interop context' do
 
     inspect_zip_with_external_tool(tf.path)
   end
+  
+  it 'creates an archive using data descriptors, with a small number of very tiny text files' do
+    tf = ManagedTempfile.new('zip')
+    z = described_class.new
+
+    test_str = Random.new.bytes(64)
+    crc = Zlib.crc32(test_str)
+    t = Time.now.utc
+
+    3.times do |i|
+      fn = "test-#{i}"
+      z.add_local_file_header_of_unknown_size(io: tf, filename: fn, storage_mode: 0)
+      tf << test_str
+      z.write_data_descriptor(io: tf, crc32: crc, compressed_size: test_str.bytesize, uncompressed_size: test_str.bytesize)
+    end
+    z.write_central_directory(tf)
+    tf.flush
+
+    Zip::File.open(tf.path) do |zip_file|
+      entries = zip_file.to_a
+      expect(entries.length).to eq(3)
+      entries.each do |entry|
+        # Make sure it is tagged as UNIX
+        expect(entry.fstype).to eq(3)
+
+        # Check the file contents
+        readback = entry.get_input_stream.read
+        readback.force_encoding(Encoding::BINARY)
+        expect(readback).to eq(test_str)
+
+        # The CRC
+        expect(entry.crc).to eq(crc)
+
+        # Check the name
+        expect(entry.name).to match(/test/)
+
+        # Check the right external attributes (non-executable on UNIX)
+        expect(entry.external_file_attributes).to eq(2175008768)
+      end
+    end
+
+    inspect_zip_with_external_tool(tf.path)
+  end
 end

--- a/testing/generate_test_files.rb
+++ b/testing/generate_test_files.rb
@@ -18,7 +18,7 @@ build_test "Filename with diacritics" do |zip|
   zip << $war_and_peace
 end
 
-xbuild_test "Purely UTF-8 filename" do |zip|
+build_test "Purely UTF-8 filename" do |zip|
   zip.add_stored_entry('Война и мир.txt', $war_and_peace.bytesize, $war_and_peace_crc)
   zip << $war_and_peace
 end

--- a/testing/generate_test_files.rb
+++ b/testing/generate_test_files.rb
@@ -18,7 +18,7 @@ build_test "Filename with diacritics" do |zip|
   zip << $war_and_peace
 end
 
-build_test "Purely UTF-8 filename" do |zip|
+xbuild_test "Purely UTF-8 filename" do |zip|
   zip.add_stored_entry('Война и мир.txt', $war_and_peace.bytesize, $war_and_peace_crc)
   zip << $war_and_peace
 end
@@ -52,7 +52,7 @@ build_test "One tiny entry followed by second that requires Zip64" do |zip|
   big.write_to(zip)
 end
 
-xbuild_test "Two entries both requiring Zip64" do |zip|
+build_test "Two entries both requiring Zip64" do |zip|
   big = generate_big_entry(0xFFFFFFFF + 2048)
   zip.add_stored_entry('huge-file-1.bin', big.size, big.crc32)
   big.write_to(zip)
@@ -63,18 +63,21 @@ end
 
 DD = ZipTricks::CompressingStreamer 
 
-build_test "Two stored entries using data descriptors", streamer_class: DD do |zip|
+build_test "Five different entries (stored/deflated) using data descriptors", streamer_class: DD do |zip|
   zip.write_stored_file('stored.1.bin') do |sink|
     sink << Random.new.bytes(1024 * 1024 * 4)
   end
   zip.write_stored_file('stored.2.bin') do |sink|
-    sink << Random.new.bytes(1024 * 1024 * 3)
+    sink << Random.new.bytes(1024 * 1024 * 2)
   end
-end
-
-build_test "One entry deflated using data descriptors", streamer_class: DD do |zip|
   zip.write_deflated_file('compressed_text.txt') do |sink|
     sink << $war_and_peace
+  end
+  zip.write_stored_file('stored.3.bin') do |sink|
+    sink << Random.new.bytes(1024 * 1024 * 1)
+  end
+  zip.write_deflated_file('deflated.4.bin') do |sink|
+    sink << Random.new.bytes(1024 * 1024 * 2)
   end
 end
 

--- a/testing/support.rb
+++ b/testing/support.rb
@@ -34,7 +34,7 @@ at_exit { $builder_threads.map(&:join) }
 def build_test(test_description, desired_outcome: "Opens and files extract", streamer_class: ZipTricks::Streamer)
   $tests_performed += 1
 
-  test_file_base = test_description.downcase.gsub(/\-/, '').gsub(/[\s\:]+/, '_')
+  test_file_base = test_description.downcase.gsub(/[^\w]/, '_').gsub(/[\s\:]+/, '_')
   filename = '%02d-%s.zip' % [$tests_performed, test_file_base]
 
   puts 'Test %02d: %s' % [$tests_performed, test_description]

--- a/testing/support.rb
+++ b/testing/support.rb
@@ -31,7 +31,7 @@ $tests_performed = 0
 $test_descs = []
 $builder_threads = []
 at_exit { $builder_threads.map(&:join) }
-def build_test(test_description, desired_outcome="Opens and files extract")
+def build_test(test_description, desired_outcome: "Opens and files extract", streamer_class: ZipTricks::Streamer)
   $tests_performed += 1
 
   test_file_base = test_description.downcase.gsub(/\-/, '').gsub(/[\s\:]+/, '_')
@@ -44,7 +44,7 @@ def build_test(test_description, desired_outcome="Opens and files extract")
   $test_descs << TestDesc.new(test_description, filename, desired_outcome)
   $builder_threads << Thread.new do
     File.open(File.join(__dir__, filename + '.tmp'), 'wb') do |of|
-      ZipTricks::Streamer.open(of) do |zip|
+      streamer_class.open(of) do |zip|
         yield(zip)
       end
     end


### PR DESCRIPTION
Please investigate whether we can make this work. I am also very curious why the test with those descriptors fails (Rubyzip refuses to open them correctly - it reads 2 bytes ahead of the start of the entry somehow).

Please do not merge but continue on this branch. This is not something pressing, but a nice to have.