### PR TITLE
Set the disk number to 0xFFFF when Zip64 extra field is involved

### DIFF
--- a/IMPLEMENTATION_DETAILS.md
+++ b/IMPLEMENTATION_DETAILS.md
@@ -9,8 +9,8 @@ The ZipTricks streaming implementation is designed around the following requirem
 It strives to be compatible with the following unzip programs _at the minimum:_
 
 * OSX - builtin ArchiveUtility (except the Zip64 support when files larger than 4GB are in the archive)
-* OSX - The Unarchiver, recent versions
-* Windows 7 -built-in Explorer zip browser (except for Unicode filenames which it just doesn't support)
+* OSX - The Unarchiver, at least 3.10.1
+* Windows 7 - built-in Explorer zip browser (except for Unicode filenames which it just doesn't support)
 * Windows 7 - 7Zip 9.20
 
 Below is the list of _specific_ decisions taken when writing the implementation, with an explanation for each.

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -285,10 +285,10 @@ class ZipTricks::Microzip
                                                              # offset of start of central
                                                              # directory with respect to
       io << [start_of_central_directory].pack(C_Qe)          # the starting disk number        8 bytes
-                                                              # zip64 extensible data sector    (variable size)
+                                                             # zip64 extensible data sector    (variable size), blank for us
 
       # [zip64 end of central directory locator]
-      io << [0x07064b50].pack("V")                           # zip64 end of central dir locator
+      io << [0x07064b50].pack(C_V)                           # zip64 end of central dir locator
                                                              # signature                       4 bytes  (0x07064b50)
       io << [0].pack(C_V)                                    # number of the disk with the
                                                              # start of the zip64 end of

--- a/lib/zip_tricks/microzip.rb
+++ b/lib/zip_tricks/microzip.rb
@@ -173,9 +173,16 @@ class ZipTricks::Microzip
       io << [extra_size].pack(C_v)                        # extra field length              2 bytes
 
       io << [0].pack(C_v)                                 # file comment length             2 bytes
-      io << [0].pack(C_v)                                 # disk number start               2 bytes
-      io << [0].pack(C_v)                                 # internal file attributes        2 bytes
       
+      # For The Unarchiver < 3.11.1 this field has to be set to the overflow value if zip64 is used
+      # because otherwise it does not properly advance the pointer when reading the Zip64 extra field
+      # https://bitbucket.org/WAHa_06x36/theunarchiver/pull-requests/2/bug-fix-for-zip64-extra-field-parser/diff
+      if @requires_zip64
+        io << [TWO_BYTE_MAX_UINT].pack(C_v)               # disk number start               2 bytes
+      else
+        io << [0].pack(C_v)                               # disk number start               2 bytes
+      end
+      io << [0].pack(C_v)                                # internal file attributes        2 bytes
       io << [DEFAULT_EXTERNAL_ATTRS].pack(C_V)           # external file attributes        4 bytes
 
       if @requires_zip64

--- a/spec/zip_tricks/microzip_spec.rb
+++ b/spec/zip_tricks/microzip_spec.rb
@@ -46,7 +46,7 @@ describe ZipTricks::Microzip do
     expect(br.read_2b).to eq(filename.size)         # filename length
     expect(br.read_2b).to eq(extra_field)          # extra field
     expect(br.read_2b).to eq(0)          # file comment
-    expect(br.read_2b).to eq(0)          # disk number
+    expect(br.read_2b).to eq(0xFFFF)     # disk number, must be blanked to the maximum value because of The Unarchiver bug
     expect(br.read_2b).to eq(0)          # internal file attributes
     expect(br.read_4b).to eq(2175008768) # external file attributes
     expect(br.read_4b).to eq(relative_offset)          # relative offset of local header


### PR DESCRIPTION
to make things work with The Unarchiver 3.10

This also rejigs the microzip test for more verbosity (see commit messages for an explanation)