### PR TITLE
Fix quadratic perf problem when uniqing filenames

### DIFF
--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -18,6 +18,24 @@ describe ZipTricks::Streamer do
   def rewind_after(*ios)
     yield.tap { ios.map(&:rewind) }
   end
+  
+  it'is able to deal with an obscene number of files in the ZIP' do
+    d = double()
+    allow(d).to receive(:write_local_file_header)
+    allow(d).to receive(:write_data_descriptor)
+    allow(d).to receive(:write_central_directory_file_header)
+    allow(d).to receive(:write_end_of_central_directory)
+    
+    described_class.open(ZipTricks::NullWriter, writer: d) do |w|
+      40_000.times do |i|
+        w.write_stored_file('%0004d_file' % i) {|body| body << 'w' }
+      end
+    end
+
+    # If there is a performance problem with file counts you will notice
+    # that this test is taking forever
+    expect(true).to eq(true)
+  end
 
   it 'raises an InvalidOutput if the given object does not support the methods' do
     expect {

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../spec_helper'
+require 'complexity_assert'
 
 describe ZipTricks::Streamer do
   let(:test_text_file_path) {
@@ -18,23 +19,32 @@ describe ZipTricks::Streamer do
   def rewind_after(*ios)
     yield.tap { ios.map(&:rewind) }
   end
-  
-  it'is able to deal with an obscene number of files in the ZIP' do
-    d = double()
-    allow(d).to receive(:write_local_file_header)
-    allow(d).to receive(:write_data_descriptor)
-    allow(d).to receive(:write_central_directory_file_header)
-    allow(d).to receive(:write_end_of_central_directory)
-    
-    described_class.open(ZipTricks::NullWriter, writer: d) do |w|
-      40_000.times do |i|
-        w.write_stored_file('%0004d_file' % i) {|body| body << 'w' }
+
+  class FakeZipWriter
+    def write_local_file_header(*);               end
+    def write_data_descriptor(*);                 end
+    def write_central_directory_file_header(*);   end
+    def write_central_directory_file_header(*);   end
+    def write_end_of_central_directory(*);        end
+  end
+
+  it'has linear performance depending on the file count' do
+
+    module FilecountComplexity
+      def self.generate_args(size)
+        [size]
+      end
+
+      def self.run(n_files)
+        ZipTricks::Streamer.open(ZipTricks::NullWriter, writer: FakeZipWriter.new) do |w|
+          n_files.times do |i|
+            w.write_stored_file('file_%d' % i) {|body| body << 'w' }
+          end
+        end
       end
     end
-
-    # If there is a performance problem with file counts you will notice
-    # that this test is taking forever
-    expect(true).to eq(true)
+    
+    expect(FilecountComplexity).to be_linear
   end
 
   it 'raises an InvalidOutput if the given object does not support the methods' do

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -33,9 +33,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubyzip', '~> 1.1'
   spec.add_development_dependency 'terminal-table'
   spec.add_development_dependency 'range_utils'
+  
   spec.add_development_dependency 'rack', '~> 1.6' # For Jeweler
   spec.add_development_dependency 'rake', '~> 10.4'
-  spec.add_development_dependency "rspec", "~> 3.2.0", '< 3.3'
+  spec.add_development_dependency "rspec", "~> 3"
+  spec.add_development_dependency 'complexity_assert'
   spec.add_development_dependency 'coderay'
   spec.add_development_dependency "yard", "~> 0.9"
   


### PR DESCRIPTION
We check for unique filenames using a `.any?` on an
Array. It is going to take longer as the array grows,
since `any?` needs to do an array scan. This leads to
a quadratic performance regression when file counts in
the ZIP become large.

Without this patch, writing 40000 fake files into
a null writer takes _minutes_.