### PR TITLE
write the correct crc32

### DIFF
--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -342,7 +342,7 @@ class ZipTricks::Streamer
   def write_data_descriptor_for_last_entry
     e = @files.fetch(-1)
     @writer.write_data_descriptor(io: @out,
-                                  crc32: 0,
+                                  crc32: e.crc32,
                                   compressed_size: e.compressed_size,
                                   uncompressed_size: e.uncompressed_size)
   end


### PR DESCRIPTION
introduced by abb175a75c4eb9b7067d53f4b9dd8420d2a75684

This broke windows excel, though it worked with mac numbers and unzip
also had no problem either.