### PR TITLE
Fix data descriptor CRC output from Streamer

### DIFF
--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -211,11 +211,7 @@ class ZipTricks::Streamer
     last_entry.crc32 = crc
     last_entry.compressed_size = comp
     last_entry.uncompressed_size = uncomp
-
-    @writer.write_data_descriptor(io: @out,
-                                  crc32: crc,
-                                  compressed_size: comp,
-                                  uncompressed_size: uncomp)
+    write_data_descriptor_for_last_entry
   end
 
   # Opens the stream for a deflated file in the archive, and yields a writer

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 # Is used to write streamed ZIP archives into the provided IO-ish object.
 # The output IO is never going to be rewound or seeked, so the output
 # of this object can be coupled directly to, say, a Rack output.

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -342,7 +342,7 @@ class ZipTricks::Streamer
   def write_data_descriptor_for_last_entry
     e = @files.fetch(-1)
     @writer.write_data_descriptor(io: @out,
-                                  crc32: 0,
+                                  crc32: e.crc32,
                                   compressed_size: e.compressed_size,
                                   uncompressed_size: e.uncompressed_size)
   end

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -304,6 +304,41 @@ describe ZipTricks::Streamer do
     end
   end
 
+  it 'writes the correct archive elements when using data descriptors' do
+    out = StringIO.new
+    fake_w = double('Writer')
+    expect(fake_w).to receive(:write_local_file_header) {|**kwargs|
+      expect(kwargs[:storage_mode]).to eq(8)
+      expect(kwargs[:crc32]).to be_zero
+      expect(kwargs[:filename]).to eq('somefile.txt')
+    }
+    expect(fake_w).to receive(:write_data_descriptor) {|**kwargs|
+      expect(kwargs[:crc32]).to eq(2729945713)
+      expect(kwargs[:compressed_size]).to eq(19)
+      expect(kwargs[:uncompressed_size]).to eq(17)
+    }
+    expect(fake_w).to receive(:write_central_directory_file_header) {|**kwargs|
+      expect(kwargs[:local_file_header_location]).to eq(0)
+      expect(kwargs[:filename]).to eq('somefile.txt')
+      expect(kwargs[:gp_flags]).to eq(8)
+      expect(kwargs[:storage_mode]).to eq(8)
+      expect(kwargs[:compressed_size]).to eq(19)
+      expect(kwargs[:uncompressed_size]).to eq(17)
+      expect(kwargs[:crc32]).to eq(2729945713)
+      kwargs[:io] << "fake"
+    }
+    expect(fake_w).to receive(:write_end_of_central_directory) {|**kwargs|
+      expect(kwargs[:start_of_central_directory_location]).to be > 0
+      expect(kwargs[:central_directory_size]).to be > 0
+      expect(kwargs[:num_files_in_archive]).to eq(1)
+    }
+    ZipTricks::Streamer.open(out, writer: fake_w) do |z|
+      z.write_deflated_file('somefile.txt') do |out|
+        out << "Experimental data"
+      end
+    end
+  end
+
   it 'creates an archive with data descriptors that can be opened by Rubyzip, \
       with a small number of very tiny text files' do
     tf = ManagedTempfile.new('zip')


### PR DESCRIPTION
Supercedes #20 and should have a test as well. Previously we would mistakenly be writing out 0 as the CRC value.