### PR TITLE
Adjust CRC32 buffer size to 64 KB and use a buffering wrapper for IO

### DIFF
--- a/bench/buffered_crc32_bench.rb
+++ b/bench/buffered_crc32_bench.rb
@@ -1,0 +1,111 @@
+require 'bundler'
+Bundler.setup
+
+require 'benchmark'
+require 'benchmark/ips'
+require_relative '../lib/zip_tricks'
+
+# Create an array of 15 bytes
+data = Random.new.bytes(5*1024*1024).unpack("C*")
+buffer_sizes = [
+  1,
+  256,
+  512,
+  1024,
+  8*1024,
+  16*1024,
+  32*1024,
+  64*1024,
+  128*1024,
+  256*1024,
+  512*1024,
+  1024*1024,
+  2*1024*1024,
+]
+
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+  x.config(:time => 5, :warmup => 2)
+  buffer_sizes.each do |buf_size|
+    x.report "Single-byte <<-writes of #{data.length} using a #{buf_size} byte buffer" do
+      crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, buf_size)
+      data.each { |byte| crc << byte }
+      crc.to_i
+    end
+  end
+  x.compare!
+end
+
+__END__
+
+julik@jet zip_tricks (buffer-write) $ ruby bench/buffered_crc32_bench.rb 
+Warming up --------------------------------------
+Single-bute writes of 5242880 using a 1 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 256 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 512 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 1024 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 8192 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 16384 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 32768 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 65536 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 131072 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 262144 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 524288 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 1048576 byte buffer
+                         1.000  i/100ms
+Single-bute writes of 5242880 using a 2097152 byte buffer
+                         1.000  i/100ms
+Calculating -------------------------------------
+Single-bute writes of 5242880 using a 1 byte buffer
+                          0.051  (± 0.0%) i/s -      1.000  in  19.438758s
+Single-bute writes of 5242880 using a 256 byte buffer
+                          0.287  (± 0.0%) i/s -      2.000  in   6.966893s
+Single-bute writes of 5242880 using a 512 byte buffer
+                          0.312  (± 0.0%) i/s -      2.000  in   6.400392s
+Single-bute writes of 5242880 using a 1024 byte buffer
+                          0.331  (± 0.0%) i/s -      2.000  in   6.036335s
+Single-bute writes of 5242880 using a 8192 byte buffer
+                          0.360  (± 0.0%) i/s -      2.000  in   5.558613s
+Single-bute writes of 5242880 using a 16384 byte buffer
+                          0.364  (± 0.0%) i/s -      2.000  in   5.489236s
+Single-bute writes of 5242880 using a 32768 byte buffer
+                          0.367  (± 0.0%) i/s -      2.000  in   5.451628s
+Single-bute writes of 5242880 using a 65536 byte buffer
+                          0.369  (± 0.0%) i/s -      2.000  in   5.426813s
+Single-bute writes of 5242880 using a 131072 byte buffer
+                          0.366  (± 0.0%) i/s -      2.000  in   5.459224s
+Single-bute writes of 5242880 using a 262144 byte buffer
+                          0.357  (± 0.0%) i/s -      2.000  in   5.594680s
+Single-bute writes of 5242880 using a 524288 byte buffer
+                          0.358  (± 0.0%) i/s -      2.000  in   5.590514s
+Single-bute writes of 5242880 using a 1048576 byte buffer
+                          0.357  (± 0.0%) i/s -      2.000  in   5.599562s
+Single-bute writes of 5242880 using a 2097152 byte buffer
+                          0.355  (± 0.0%) i/s -      2.000  in   5.626917s
+
+Comparison:
+Single-bute writes of 5242880 using a 65536 byte buffer:        0.4 i/s
+Single-bute writes of 5242880 using a 32768 byte buffer:        0.4 i/s - 1.00x  slower
+Single-bute writes of 5242880 using a 131072 byte buffer:        0.4 i/s - 1.01x  slower
+Single-bute writes of 5242880 using a 16384 byte buffer:        0.4 i/s - 1.01x  slower
+Single-bute writes of 5242880 using a 8192 byte buffer:        0.4 i/s - 1.02x  slower
+Single-bute writes of 5242880 using a 524288 byte buffer:        0.4 i/s - 1.03x  slower
+Single-bute writes of 5242880 using a 262144 byte buffer:        0.4 i/s - 1.03x  slower
+Single-bute writes of 5242880 using a 1048576 byte buffer:        0.4 i/s - 1.03x  slower
+Single-bute writes of 5242880 using a 2097152 byte buffer:        0.4 i/s - 1.04x  slower
+Single-bute writes of 5242880 using a 1024 byte buffer:        0.3 i/s - 1.11x  slower
+Single-bute writes of 5242880 using a 512 byte buffer:        0.3 i/s - 1.18x  slower
+Single-bute writes of 5242880 using a 256 byte buffer:        0.3 i/s - 1.28x  slower
+Single-bute writes of 5242880 using a 1 byte buffer:        0.1 i/s - 7.16x  slower

--- a/bench/buffered_crc32_bench.rb
+++ b/bench/buffered_crc32_bench.rb
@@ -5,7 +5,7 @@ require 'benchmark'
 require 'benchmark/ips'
 require_relative '../lib/zip_tricks'
 
-data = Random.new.bytes(5 * 1024 * 1024).unpack('C*')
+data = Random.new.bytes(5 * 1024 * 1024).split(//)
 buffer_sizes = [
   1,
   256,

--- a/bench/buffered_crc32_bench.rb
+++ b/bench/buffered_crc32_bench.rb
@@ -69,59 +69,43 @@ Single-byte <<-writes of 5242880 using a 2097152 byte buffer
                          1.000  i/100ms
 Calculating -------------------------------------
 Single-byte <<-writes of 5242880 using a 1 byte buffer
-                          0.056  (± 0.0%) i/s -      1.000  in  17.757238s
+                          0.054  (± 0.0%) i/s -      1.000  in  18.383019s
 Single-byte <<-writes of 5242880 using a 256 byte buffer
-                          0.125  (± 0.0%) i/s -      1.000  in   7.990842s
+                          0.121  (± 0.0%) i/s -      1.000  in   8.286061s
 Single-byte <<-writes of 5242880 using a 512 byte buffer
-                          0.129  (± 0.0%) i/s -      1.000  in   7.723896s
+                          0.124  (± 0.0%) i/s -      1.000  in   8.038112s
 Single-byte <<-writes of 5242880 using a 1024 byte buffer
-                          0.131  (± 0.0%) i/s -      1.000  in   7.634909s
+                          0.128  (± 0.0%) i/s -      1.000  in   7.828562s
 Single-byte <<-writes of 5242880 using a 8192 byte buffer
-                          0.134  (± 0.0%) i/s -      1.000  in   7.458469s
+                          0.123  (± 0.0%) i/s -      1.000  in   8.121586s
 Single-byte <<-writes of 5242880 using a 16384 byte buffer
-                          0.134  (± 0.0%) i/s -      1.000  in   7.455839s
+                          0.127  (± 0.0%) i/s -      1.000  in   7.872240s
 Single-byte <<-writes of 5242880 using a 32768 byte buffer
-                          0.134  (± 0.0%) i/s -      1.000  in   7.484182s
+                          0.126  (± 0.0%) i/s -      1.000  in   7.911816s
 Single-byte <<-writes of 5242880 using a 65536 byte buffer
-                          0.136  (± 0.0%) i/s -      1.000  in   7.340512s
+                          0.126  (± 0.0%) i/s -      1.000  in   7.917318s
 Single-byte <<-writes of 5242880 using a 131072 byte buffer
-                          0.137  (± 0.0%) i/s -      1.000  in   7.314390s
+                          0.127  (± 0.0%) i/s -      1.000  in   7.897223s
 Single-byte <<-writes of 5242880 using a 262144 byte buffer
-                          0.133  (± 0.0%) i/s -      1.000  in   7.496164s
+                          0.130  (± 0.0%) i/s -      1.000  in   7.675608s
 Single-byte <<-writes of 5242880 using a 524288 byte buffer
-                          0.135  (± 0.0%) i/s -      1.000  in   7.417235s
+                          0.130  (± 0.0%) i/s -      1.000  in   7.679886s
 Single-byte <<-writes of 5242880 using a 1048576 byte buffer
-                          0.136  (± 0.0%) i/s -      1.000  in   7.355934s
+                          0.128  (± 0.0%) i/s -      1.000  in   7.788439s
 Single-byte <<-writes of 5242880 using a 2097152 byte buffer
-                          0.135  (± 0.0%) i/s -      1.000  in   7.389307s
+                          0.128  (± 0.0%) i/s -      1.000  in   7.797839s
 
 Comparison:
-<<<<<<< HEAD
-Single-bute writes of 5242880 using a 65536 byte buffer:        0.4 i/s
-Single-bute writes of 5242880 using a 32768 byte buffer:        0.4 i/s - 1.00x  slower
-Single-bute writes of 5242880 using a 131072 byte buffer:        0.4 i/s - 1.01x  slower
-Single-bute writes of 5242880 using a 16384 byte buffer:        0.4 i/s - 1.01x  slower
-Single-bute writes of 5242880 using a 8192 byte buffer:        0.4 i/s - 1.02x  slower
-Single-bute writes of 5242880 using a 524288 byte buffer:        0.4 i/s - 1.03x  slower
-Single-bute writes of 5242880 using a 262144 byte buffer:        0.4 i/s - 1.03x  slower
-Single-bute writes of 5242880 using a 1048576 byte buffer:        0.4 i/s - 1.03x  slower
-Single-bute writes of 5242880 using a 2097152 byte buffer:        0.4 i/s - 1.04x  slower
-Single-bute writes of 5242880 using a 1024 byte buffer:        0.3 i/s - 1.11x  slower
-Single-bute writes of 5242880 using a 512 byte buffer:        0.3 i/s - 1.18x  slower
-Single-bute writes of 5242880 using a 256 byte buffer:        0.3 i/s - 1.28x  slower
-Single-bute writes of 5242880 using a 1 byte buffer:        0.1 i/s - 7.16x  slower
-=======
-Single-byte <<-writes of 5242880 using a 131072 byte buffer:        0.1 i/s
-Single-byte <<-writes of 5242880 using a 65536 byte buffer:        0.1 i/s - 1.00x  slower
+Single-byte <<-writes of 5242880 using a 262144 byte buffer:        0.1 i/s
+Single-byte <<-writes of 5242880 using a 524288 byte buffer:        0.1 i/s - 1.00x  slower
 Single-byte <<-writes of 5242880 using a 1048576 byte buffer:        0.1 i/s - 1.01x  slower
-Single-byte <<-writes of 5242880 using a 2097152 byte buffer:        0.1 i/s - 1.01x  slower
-Single-byte <<-writes of 5242880 using a 524288 byte buffer:        0.1 i/s - 1.01x  slower
-Single-byte <<-writes of 5242880 using a 16384 byte buffer:        0.1 i/s - 1.02x  slower
-Single-byte <<-writes of 5242880 using a 8192 byte buffer:        0.1 i/s - 1.02x  slower
-Single-byte <<-writes of 5242880 using a 32768 byte buffer:        0.1 i/s - 1.02x  slower
-Single-byte <<-writes of 5242880 using a 262144 byte buffer:        0.1 i/s - 1.02x  slower
-Single-byte <<-writes of 5242880 using a 1024 byte buffer:        0.1 i/s - 1.04x  slower
-Single-byte <<-writes of 5242880 using a 512 byte buffer:        0.1 i/s - 1.06x  slower
-Single-byte <<-writes of 5242880 using a 256 byte buffer:        0.1 i/s - 1.09x  slower
-Single-byte <<-writes of 5242880 using a 1 byte buffer:        0.1 i/s - 2.43x  slower
->>>>>>> When we say "byte" it should be a byte
+Single-byte <<-writes of 5242880 using a 2097152 byte buffer:        0.1 i/s - 1.02x  slower
+Single-byte <<-writes of 5242880 using a 1024 byte buffer:        0.1 i/s - 1.02x  slower
+Single-byte <<-writes of 5242880 using a 16384 byte buffer:        0.1 i/s - 1.03x  slower
+Single-byte <<-writes of 5242880 using a 131072 byte buffer:        0.1 i/s - 1.03x  slower
+Single-byte <<-writes of 5242880 using a 32768 byte buffer:        0.1 i/s - 1.03x  slower
+Single-byte <<-writes of 5242880 using a 65536 byte buffer:        0.1 i/s - 1.03x  slower
+Single-byte <<-writes of 5242880 using a 512 byte buffer:        0.1 i/s - 1.05x  slower
+Single-byte <<-writes of 5242880 using a 8192 byte buffer:        0.1 i/s - 1.06x  slower
+Single-byte <<-writes of 5242880 using a 256 byte buffer:        0.1 i/s - 1.08x  slower
+Single-byte <<-writes of 5242880 using a 1 byte buffer:        0.1 i/s - 2.39x  slower

--- a/bench/buffered_crc32_bench.rb
+++ b/bench/buffered_crc32_bench.rb
@@ -6,27 +6,27 @@ require 'benchmark/ips'
 require_relative '../lib/zip_tricks'
 
 # Create an array of 15 bytes
-data = Random.new.bytes(5*1024*1024).unpack("C*")
+data = Random.new.bytes(5 * 1024 * 1024).unpack('C*')
 buffer_sizes = [
   1,
   256,
   512,
   1024,
-  8*1024,
-  16*1024,
-  32*1024,
-  64*1024,
-  128*1024,
-  256*1024,
-  512*1024,
-  1024*1024,
-  2*1024*1024,
+  8 * 1024,
+  16 * 1024,
+  32 * 1024,
+  64 * 1024,
+  128 * 1024,
+  256 * 1024,
+  512 * 1024,
+  1024 * 1024,
+  2 * 1024 * 1024
 ]
 
 require 'benchmark/ips'
 
 Benchmark.ips do |x|
-  x.config(:time => 5, :warmup => 2)
+  x.config(time: 5, warmup: 2)
   buffer_sizes.each do |buf_size|
     x.report "Single-byte <<-writes of #{data.length} using a #{buf_size} byte buffer" do
       crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, buf_size)

--- a/bench/buffered_crc32_bench.rb
+++ b/bench/buffered_crc32_bench.rb
@@ -5,7 +5,9 @@ require 'benchmark'
 require 'benchmark/ips'
 require_relative '../lib/zip_tricks'
 
-data = Random.new.bytes(5 * 1024 * 1024).split(//)
+n_bytes = 5 * 1024 * 1024
+r = Random.new
+bytes = (0...n_bytes).map { r.bytes(1) }
 buffer_sizes = [
   1,
   256,
@@ -24,12 +26,13 @@ buffer_sizes = [
 
 require 'benchmark/ips'
 
+
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
   buffer_sizes.each do |buf_size|
-    x.report "Single-byte <<-writes of #{data.length} using a #{buf_size} byte buffer" do
+    x.report "Single-byte <<-writes of #{n_bytes} using a #{buf_size} byte buffer" do
       crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, buf_size)
-      data.each { |byte| crc << byte }
+      bytes.each { |b| crc << b }
       crc.to_i
     end
   end
@@ -38,63 +41,63 @@ end
 
 __END__
 
-julik@jet zip_tricks (buffer-write) $ ruby bench/buffered_crc32_bench.rb 
 Warming up --------------------------------------
-Single-bute writes of 5242880 using a 1 byte buffer
+Single-byte <<-writes of 5242880 using a 1 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 256 byte buffer
+Single-byte <<-writes of 5242880 using a 256 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 512 byte buffer
+Single-byte <<-writes of 5242880 using a 512 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 1024 byte buffer
+Single-byte <<-writes of 5242880 using a 1024 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 8192 byte buffer
+Single-byte <<-writes of 5242880 using a 8192 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 16384 byte buffer
+Single-byte <<-writes of 5242880 using a 16384 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 32768 byte buffer
+Single-byte <<-writes of 5242880 using a 32768 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 65536 byte buffer
+Single-byte <<-writes of 5242880 using a 65536 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 131072 byte buffer
+Single-byte <<-writes of 5242880 using a 131072 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 262144 byte buffer
+Single-byte <<-writes of 5242880 using a 262144 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 524288 byte buffer
+Single-byte <<-writes of 5242880 using a 524288 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 1048576 byte buffer
+Single-byte <<-writes of 5242880 using a 1048576 byte buffer
                          1.000  i/100ms
-Single-bute writes of 5242880 using a 2097152 byte buffer
+Single-byte <<-writes of 5242880 using a 2097152 byte buffer
                          1.000  i/100ms
 Calculating -------------------------------------
-Single-bute writes of 5242880 using a 1 byte buffer
-                          0.051  (± 0.0%) i/s -      1.000  in  19.438758s
-Single-bute writes of 5242880 using a 256 byte buffer
-                          0.287  (± 0.0%) i/s -      2.000  in   6.966893s
-Single-bute writes of 5242880 using a 512 byte buffer
-                          0.312  (± 0.0%) i/s -      2.000  in   6.400392s
-Single-bute writes of 5242880 using a 1024 byte buffer
-                          0.331  (± 0.0%) i/s -      2.000  in   6.036335s
-Single-bute writes of 5242880 using a 8192 byte buffer
-                          0.360  (± 0.0%) i/s -      2.000  in   5.558613s
-Single-bute writes of 5242880 using a 16384 byte buffer
-                          0.364  (± 0.0%) i/s -      2.000  in   5.489236s
-Single-bute writes of 5242880 using a 32768 byte buffer
-                          0.367  (± 0.0%) i/s -      2.000  in   5.451628s
-Single-bute writes of 5242880 using a 65536 byte buffer
-                          0.369  (± 0.0%) i/s -      2.000  in   5.426813s
-Single-bute writes of 5242880 using a 131072 byte buffer
-                          0.366  (± 0.0%) i/s -      2.000  in   5.459224s
-Single-bute writes of 5242880 using a 262144 byte buffer
-                          0.357  (± 0.0%) i/s -      2.000  in   5.594680s
-Single-bute writes of 5242880 using a 524288 byte buffer
-                          0.358  (± 0.0%) i/s -      2.000  in   5.590514s
-Single-bute writes of 5242880 using a 1048576 byte buffer
-                          0.357  (± 0.0%) i/s -      2.000  in   5.599562s
-Single-bute writes of 5242880 using a 2097152 byte buffer
-                          0.355  (± 0.0%) i/s -      2.000  in   5.626917s
+Single-byte <<-writes of 5242880 using a 1 byte buffer
+                          0.056  (± 0.0%) i/s -      1.000  in  17.757238s
+Single-byte <<-writes of 5242880 using a 256 byte buffer
+                          0.125  (± 0.0%) i/s -      1.000  in   7.990842s
+Single-byte <<-writes of 5242880 using a 512 byte buffer
+                          0.129  (± 0.0%) i/s -      1.000  in   7.723896s
+Single-byte <<-writes of 5242880 using a 1024 byte buffer
+                          0.131  (± 0.0%) i/s -      1.000  in   7.634909s
+Single-byte <<-writes of 5242880 using a 8192 byte buffer
+                          0.134  (± 0.0%) i/s -      1.000  in   7.458469s
+Single-byte <<-writes of 5242880 using a 16384 byte buffer
+                          0.134  (± 0.0%) i/s -      1.000  in   7.455839s
+Single-byte <<-writes of 5242880 using a 32768 byte buffer
+                          0.134  (± 0.0%) i/s -      1.000  in   7.484182s
+Single-byte <<-writes of 5242880 using a 65536 byte buffer
+                          0.136  (± 0.0%) i/s -      1.000  in   7.340512s
+Single-byte <<-writes of 5242880 using a 131072 byte buffer
+                          0.137  (± 0.0%) i/s -      1.000  in   7.314390s
+Single-byte <<-writes of 5242880 using a 262144 byte buffer
+                          0.133  (± 0.0%) i/s -      1.000  in   7.496164s
+Single-byte <<-writes of 5242880 using a 524288 byte buffer
+                          0.135  (± 0.0%) i/s -      1.000  in   7.417235s
+Single-byte <<-writes of 5242880 using a 1048576 byte buffer
+                          0.136  (± 0.0%) i/s -      1.000  in   7.355934s
+Single-byte <<-writes of 5242880 using a 2097152 byte buffer
+                          0.135  (± 0.0%) i/s -      1.000  in   7.389307s
 
 Comparison:
+<<<<<<< HEAD
 Single-bute writes of 5242880 using a 65536 byte buffer:        0.4 i/s
 Single-bute writes of 5242880 using a 32768 byte buffer:        0.4 i/s - 1.00x  slower
 Single-bute writes of 5242880 using a 131072 byte buffer:        0.4 i/s - 1.01x  slower
@@ -108,3 +111,18 @@ Single-bute writes of 5242880 using a 1024 byte buffer:        0.3 i/s - 1.11x  
 Single-bute writes of 5242880 using a 512 byte buffer:        0.3 i/s - 1.18x  slower
 Single-bute writes of 5242880 using a 256 byte buffer:        0.3 i/s - 1.28x  slower
 Single-bute writes of 5242880 using a 1 byte buffer:        0.1 i/s - 7.16x  slower
+=======
+Single-byte <<-writes of 5242880 using a 131072 byte buffer:        0.1 i/s
+Single-byte <<-writes of 5242880 using a 65536 byte buffer:        0.1 i/s - 1.00x  slower
+Single-byte <<-writes of 5242880 using a 1048576 byte buffer:        0.1 i/s - 1.01x  slower
+Single-byte <<-writes of 5242880 using a 2097152 byte buffer:        0.1 i/s - 1.01x  slower
+Single-byte <<-writes of 5242880 using a 524288 byte buffer:        0.1 i/s - 1.01x  slower
+Single-byte <<-writes of 5242880 using a 16384 byte buffer:        0.1 i/s - 1.02x  slower
+Single-byte <<-writes of 5242880 using a 8192 byte buffer:        0.1 i/s - 1.02x  slower
+Single-byte <<-writes of 5242880 using a 32768 byte buffer:        0.1 i/s - 1.02x  slower
+Single-byte <<-writes of 5242880 using a 262144 byte buffer:        0.1 i/s - 1.02x  slower
+Single-byte <<-writes of 5242880 using a 1024 byte buffer:        0.1 i/s - 1.04x  slower
+Single-byte <<-writes of 5242880 using a 512 byte buffer:        0.1 i/s - 1.06x  slower
+Single-byte <<-writes of 5242880 using a 256 byte buffer:        0.1 i/s - 1.09x  slower
+Single-byte <<-writes of 5242880 using a 1 byte buffer:        0.1 i/s - 2.43x  slower
+>>>>>>> When we say "byte" it should be a byte

--- a/bench/buffered_crc32_bench.rb
+++ b/bench/buffered_crc32_bench.rb
@@ -26,7 +26,6 @@ buffer_sizes = [
 
 require 'benchmark/ips'
 
-
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
   buffer_sizes.each do |buf_size|

--- a/bench/buffered_crc32_bench.rb
+++ b/bench/buffered_crc32_bench.rb
@@ -5,7 +5,6 @@ require 'benchmark'
 require 'benchmark/ips'
 require_relative '../lib/zip_tricks'
 
-# Create an array of 15 bytes
 data = Random.new.bytes(5 * 1024 * 1024).unpack('C*')
 buffer_sizes = [
   1,

--- a/lib/zip_tricks/stream_crc32.rb
+++ b/lib/zip_tricks/stream_crc32.rb
@@ -2,21 +2,18 @@
 
 # A simple stateful class for keeping track of a CRC32 value through multiple writes
 class ZipTricks::StreamCRC32
-  BUFFER_SIZE = 1024 * 1024 * 5
-
   # Compute a CRC32 value from an IO object. The object should respond to `read` and `eof?`
   #
   # @param io[IO] the IO to read the data from
   # @return [Fixnum] the computed CRC32 value
   def self.from_io(io)
     crc = new
-    crc << io.read(BUFFER_SIZE) until io.eof?
+    crc << io.read(1024 * 512) until io.eof?
     crc.to_i
   end
 
   # Creates a new streaming CRC32 calculator
   def initialize
-    @buf = StringIO.new
     @crc = Zlib.crc32('')
   end
 
@@ -25,8 +22,7 @@ class ZipTricks::StreamCRC32
   # @param blob[String] the string to compute the CRC32 from
   # @return [self]
   def <<(blob)
-    @buf << blob
-    buf_flush if @buf.size > BUFFER_SIZE
+    @crc = Zlib.crc32_combine(@crc, Zlib.crc32(blob), blob.bytesize)
     self
   end
 
@@ -34,7 +30,6 @@ class ZipTricks::StreamCRC32
   #
   # @return [Fixnum] the updated CRC32 value for all the blobs so far
   def to_i
-    buf_flush if @buf.size > 0
     @crc
   end
 
@@ -45,15 +40,6 @@ class ZipTricks::StreamCRC32
   # @param blob_size[Fixnum] the size of the daata the `crc32` is computed from
   # @return [Fixnum] the updated CRC32 value for all the blobs so far
   def append(crc32, blob_size)
-    buf_flush if @buf.size > 0
     @crc = Zlib.crc32_combine(@crc, crc32, blob_size)
-  end
-
-  private
-
-  def buf_flush
-    @crc = Zlib.crc32_combine(@crc, Zlib.crc32(@buf.string), @buf.size)
-    @buf.truncate(0)
-    @buf.rewind
   end
 end

--- a/lib/zip_tricks/streamer/deflated_writer.rb
+++ b/lib/zip_tricks/streamer/deflated_writer.rb
@@ -12,6 +12,7 @@ class ZipTricks::Streamer::DeflatedWriter
     @started_at = @io.tell
     @crc = ZipTricks::StreamCRC32.new
     @deflater = ::Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -::Zlib::MAX_WBITS)
+    @crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, 64 * 1024)
     @bytes_since_last_flush = 0
   end
 
@@ -25,7 +26,9 @@ class ZipTricks::Streamer::DeflatedWriter
     @bytes_since_last_flush += data.bytesize
     @io << @deflater.deflate(data)
     @crc << data
+
     interim_flush
+
     self
   end
 

--- a/lib/zip_tricks/streamer/stored_writer.rb
+++ b/lib/zip_tricks/streamer/stored_writer.rb
@@ -12,7 +12,6 @@ class ZipTricks::Streamer::StoredWriter
 
   def initialize(io)
     @io = ZipTricks::WriteAndTell.new(io)
-    @started_at = @io.tell
     @crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, CRC32_BUFFER_SIZE)
   end
 

--- a/lib/zip_tricks/streamer/stored_writer.rb
+++ b/lib/zip_tricks/streamer/stored_writer.rb
@@ -4,10 +4,17 @@
 # through it in a CRC32 checksum calculator. Is made to be completely
 # interchangeable with the DeflatedWriter in terms of interface.
 class ZipTricks::Streamer::StoredWriter
+
+  # The amount of bytes we will buffer before computing the intermediate
+  # CRC32 checksums. Benchmarks show that the optimum is 64KB (see
+  # `bench/buffered_crc32_bench.rb), if that is exceeded Zlib is going
+  # to perform internal CRC combine calls which will make the speed go down again.
+  CRC32_BUFFER_SIZE = 64 * 1024
+
   def initialize(io)
     @io = ZipTricks::WriteAndTell.new(io)
     @started_at = @io.tell
-    @crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, 64 * 1024)
+    @crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, CRC32_BUFFER_SIZE)
   end
 
   # Writes the given data to the contained IO object.

--- a/lib/zip_tricks/streamer/stored_writer.rb
+++ b/lib/zip_tricks/streamer/stored_writer.rb
@@ -7,7 +7,7 @@ class ZipTricks::Streamer::StoredWriter
     @uncompressed_size = 0
     @compressed_size = 0
     @started_at = @io.tell
-    @crc = ZipTricks::StreamCRC32.new
+    @crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, 64 * 1024)
   end
 
   def <<(data)

--- a/lib/zip_tricks/streamer/stored_writer.rb
+++ b/lib/zip_tricks/streamer/stored_writer.rb
@@ -4,7 +4,6 @@
 # through it in a CRC32 checksum calculator. Is made to be completely
 # interchangeable with the DeflatedWriter in terms of interface.
 class ZipTricks::Streamer::StoredWriter
-
   # The amount of bytes we will buffer before computing the intermediate
   # CRC32 checksums. Benchmarks show that the optimum is 64KB (see
   # `bench/buffered_crc32_bench.rb), if that is exceeded Zlib is going

--- a/lib/zip_tricks/streamer/stored_writer.rb
+++ b/lib/zip_tricks/streamer/stored_writer.rb
@@ -1,23 +1,31 @@
 # frozen_string_literal: true
 
-# Rubocop: convention: Missing top-level class documentation comment.
+# Sends writes to the given `io`, and also registers all the data passing
+# through it in a CRC32 checksum calculator. Is made to be completely
+# interchangeable with the DeflatedWriter in terms of interface.
 class ZipTricks::Streamer::StoredWriter
   def initialize(io)
-    @io = io
-    @uncompressed_size = 0
-    @compressed_size = 0
+    @io = ZipTricks::WriteAndTell.new(io)
     @started_at = @io.tell
     @crc = ZipTricks::WriteBuffer.new(ZipTricks::StreamCRC32.new, 64 * 1024)
   end
 
+  # Writes the given data to the contained IO object.
+  #
+  # @param data[String] data to be written
+  # @return self
   def <<(data)
     @io << data
     @crc << data
     self
   end
 
+  # Returns the amount of data written and the CRC32 checksum. The return value
+  # can be directly used as the argument to {Streamer#update_last_entry_and_write_data_descriptor}
+  #
+  # @param data[String] data to be written
+  # @return [Hash] a hash of `{crc32, compressed_size, uncompressed_size}`
   def finish
-    size = @io.tell - @started_at
-    {crc32: @crc.to_i, compressed_size: size, uncompressed_size: size}
+    {crc32: @crc.to_i, compressed_size: @io.tell, uncompressed_size: @io.tell}
   end
 end

--- a/lib/zip_tricks/write_buffer.rb
+++ b/lib/zip_tricks/write_buffer.rb
@@ -1,0 +1,49 @@
+# Some operations (such as CRC32) benefit when they are performed
+# on larger chunks of data. In certain use cases, it is possible that
+# the consumer of ZipTricks is going to be writing small chunks
+# in rapid succession, so CRC32 is going to have to perform a lot of
+# CRC32 combine operations - and this adds up. Since the CRC32 value
+# is usually not needed until the complete output has completed
+# we can buffer at least some amount of data before computing CRC32 over it.
+class ZipTricks::WriteBuffer
+  # Creates a new WriteBuffer bypassing into a given writable object
+  #
+  # @param writable[#<<] An object that responds to `#<<` with string as argument
+  # @param buffer_size[Integer] How many bytes to buffer
+  def initialize(writable, buffer_size)
+    @buf = StringIO.new
+    @buffer_size = buffer_size
+    @writable = writable
+  end
+
+  # Appends the given data to the write buffer, and flushes the buffer into the
+  # writable if the buffer size exceeds the `buffer_size` given at initialization
+  #
+  # @param data[String] data to be written
+  # @return self
+  def <<(data)
+    @buf << data
+    flush! if @buf.size > @buffer_size
+    self
+  end
+
+  # Explicitly flushes the buffer if it contains anything
+  #
+  # @return self
+  def flush!
+    @writable << @buf.string if @buf.size > 0
+    @buf.truncate(0)
+    @buf.rewind
+    self
+  end
+
+  # Flushes the buffer and returns the result of `#to_` of the contained `writable`.
+  # Primarily facilitates working with StreamCRC32 objects where you finish the
+  # computation by retrieving the CRC as an integer
+  #
+  # @return [Integer] the return value of `writable#to_i`
+  def to_i
+    flush!
+    @writable.to_i
+  end
+end

--- a/lib/zip_tricks/write_buffer.rb
+++ b/lib/zip_tricks/write_buffer.rb
@@ -37,7 +37,7 @@ class ZipTricks::WriteBuffer
     self
   end
 
-  # Flushes the buffer and returns the result of `#to_` of the contained `writable`.
+  # Flushes the buffer and returns the result of `#to_i` of the contained `writable`.
   # Primarily facilitates working with StreamCRC32 objects where you finish the
   # computation by retrieving the CRC as an integer
   #

--- a/spec/zip_tricks/write_buffer_spec.rb
+++ b/spec/zip_tricks/write_buffer_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../spec_helper'
+
+describe ZipTricks::WriteBuffer do
+  it 'returns self from <<' do
+    sink = []
+    adapter = described_class.new(sink, 1024)
+    expect(adapter << 'a').to eq(adapter)
+  end
+
+  it 'appends the written strings in one go for the set buffer size' do
+    sink = double('Writable')
+
+    expect(sink).to receive(:<<).with('quick brown fox ')
+    expect(sink).to receive(:<<).with('jumps over the')
+    
+    adapter = described_class.new(sink, 'quick brown fox'.bytesize)
+    'quick brown fox jumps over the'.split(//).each do |char|
+      adapter << char
+    end
+
+    adapter.flush!
+  end
+
+  it 'flushes the buffer and returns `to_i` from the contained object' do
+    sink = double('Writable')
+
+    expect(sink).to receive(:<<).with('quick brown fox ')
+    expect(sink).to receive(:to_i).and_return(123)
+
+    adapter = described_class.new(sink, 64*1024)
+    'quick brown fox '.split(//).each do |char|
+      adapter << char
+    end
+
+    expect(adapter.to_i).to eq(123)
+  end
+end

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'complexity_assert'
   spec.add_development_dependency 'coderay'
+  spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'rubocop', '0.51.0' # No conforming to arbitrary rules that _change_ underneath you
 end


### PR DESCRIPTION
Even though the size of the buffer is specific to the CRC32 implementation in zlib, the pattern of buffering writes is actually pretty common - and in the StreamCRC32 objects it is not very declarative. We reimplement it as an write proxy instead, which decouples the buffering stuff and makes it possible to use it in other scenarios as well.

This also adds a benchmark that proves, as correctly stated by @felixbuenemann that the 64KB buffer size _is_ indeed the sweet spot as far as CRC32 is concerned (we intentionally perform 1-byte writes to get the slowest possible throughput and the smallest chunks). This will be beneficial to libraries like XSLX writers which are likely to be writing lots of small chunks in succession (as oposed to archive-from-file situations where `IO.copy_stream` can choose the right chunk size for us).