### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at julik@wetransfer.com and/or noah@wetransfer.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,172 @@
+# Contributing to zip_tricks
+
+Please take a moment to review this document in order to make the contribution
+process easy and effective for everyone involved.
+
+Following these guidelines helps to communicate that you respect the time of
+the developers managing and developing this open source project. In return,
+they should reciprocate that respect in addressing your issue or assessing
+patches and features.
+
+## What do I need to know to help?
+
+If you are looking to help to with a code contribution, the project uses Ruby. If you don't feel ready to make a code contribution yet, no problem -- keep an eye out on the issues page for issues tagged "good-first-issue" or "documentation-issue" -- or submit your own!
+
+If you are interested in making a code contribution and would like to learn more about the technologies that we use, check out the (non-exhaustive) list below. You can also get in touch with us via an issue or email and we can provide additional resources and information.
+
+ - [ruby](https://ruby-doc.org/stdlib-2.4.1/) (currently tested to 2.4.1)
+ - [rubyzip](https://github.com/rubyzip/rubyzip)
+ - [rspec](http://rspec.info/) (for testing)
+ - [zip files](https://en.wikipedia.org/wiki/Zip_(file_format))
+
+
+# How do I made a contribution?
+
+## Using the issue tracker
+
+The issue tracker is the preferred channel for [bug reports](#bug-reports),
+[features requests](#feature-requests) and [submitting pull
+requests](#pull-requests), but please respect the following restrictions:
+
+* Please **do not** use the issue tracker for personal support requests (use
+  [Stack Overflow](http://stackoverflow.com)).
+
+* Please **do not** derail or troll issues. Keep the discussion on topic and
+  respect the opinions of others.
+
+
+## Bug reports
+
+A bug is a _demonstrable problem_ that is caused by the code in the repository.
+Good bug reports are extremely helpful - thank you!
+
+Guidelines for bug reports:
+
+1. **Use the GitHub issue search** &mdash; check if the issue has already been
+   reported.
+
+2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
+   latest `master` or development branch in the repository.
+
+3. **Isolate the problem** &mdash; create a [reduced test
+   case](http://css-tricks.com/reduced-test-cases/) and a live example.
+
+A good bug report shouldn't leave others needing to chase you up for more
+information. Please try to be as detailed as possible in your report. What is
+your environment? What steps will reproduce the issue? What browser(s) and OS
+experience the problem? What would you expect to be the outcome? All these
+details will help people to fix any potential bugs.
+
+Example:
+
+> Short and descriptive example bug report title
+>
+> A summary of the issue and the OS environment in which it occurs. If
+> suitable, include the steps required to reproduce the bug.
+>
+> 1. This is the first step
+> 2. This is the second step
+> 3. Further steps, etc.
+>
+> `<url>` - a link to the reduced test case, if possible
+>
+> Any other information you want to share that is relevant to the issue being
+> reported. This might include the lines of code that you have identified as
+> causing the bug, and potential solutions (and your opinions on their
+> merits).
+
+
+## Feature requests
+
+Feature requests are welcome. But take a moment to find out whether your idea
+fits with the scope and aims of the project. It's up to *you* to make a strong
+case to convince the project's developers of the merits of this feature. Please
+provide as much detail and context as possible.
+
+
+## Pull requests
+
+Good pull requests - patches, improvements, new features - are a fantastic
+help. They should remain focused in scope and avoid containing unrelated
+commits.
+
+**Please ask first** before embarking on any significant pull request (e.g.
+implementing features, refactoring code, porting to a different language),
+otherwise you risk spending a lot of time working on something that the
+project's developers might not want to merge into the project.
+
+Please adhere to the coding conventions used throughout a project (indentation,
+accurate comments, etc.) and any other requirements (such as test coverage).
+
+Follow this process if you'd like your work considered for inclusion in the
+project:
+
+1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
+   and configure the remotes:
+
+   ```bash
+   # Clone your fork of the repo into the current directory
+   git clone git@github.com:WeTransfer/eslint-config-wetransfer.git
+   # Navigate to the newly cloned directory
+   cd eslint-config-wetransfer
+   # Assign the original repo to a remote called "upstream"
+   git remote add upstream git@github.com:WeTransfer/eslint-config-wetransfer.git
+   ```
+
+2. If you cloned a while ago, get the latest changes from upstream:
+
+   ```bash
+   git checkout <dev-branch>
+   git pull upstream <dev-branch>
+   ```
+
+3. Create a new topic branch (off the main project development branch) to
+   contain your feature, change, or fix:
+
+   ```bash
+   git checkout -b <topic-branch-name>
+   ```
+
+4. Commit your changes in logical chunks. Please adhere to these [AngularJS Git Commit Message Conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y)
+   or your code is unlikely be merged into the main project. Use Git's
+   [interactive rebase](https://help.github.com/articles/interactive-rebase)
+   feature to tidy up your commits before making them public.
+
+5. Locally merge (or rebase) the upstream development branch into your topic branch:
+
+   ```bash
+   git pull [--rebase] upstream <dev-branch>
+   ```
+
+6. Push your topic branch up to your fork:
+
+   ```bash
+   git push origin <topic-branch-name>
+   ```
+
+7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
+    with a clear title and description.
+
+## Conventions of commit messages
+
+Adding features on repo
+
+```bash
+git commit -m "feat: message about this feature"
+```
+
+Fixing features on repo
+
+```bash
+git commit -m "fix: message about this update"
+```
+
+Removing features on repo
+
+```bash
+git commit -m "refactor: message about this" -m "BREAKING CHANGE: message about the breaking change"
+```
+
+
+**IMPORTANT**: By submitting a patch, you agree to allow the project owner to
+license your work under the same license as that used by the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,6 @@ The issue tracker is the preferred channel for [bug reports](#bug-reports),
 [features requests](#feature-requests) and [submitting pull
 requests](#pull-requests), but please respect the following restrictions:
 
-* Please **do not** use the issue tracker for personal support requests (use
-  [Stack Overflow](http://stackoverflow.com)).
-
 * Please **do not** derail or troll issues. Keep the discussion on topic and
   respect the opinions of others.
 
@@ -98,6 +95,8 @@ project's developers might not want to merge into the project.
 Please adhere to the coding conventions used throughout a project (indentation,
 accurate comments, etc.) and any other requirements (such as test coverage).
 
+The project uses Rubocop which can be run using `bundle exec rubocop -c .rubocop.yml`.
+
 Follow this process if you'd like your work considered for inclusion in the
 project:
 
@@ -106,11 +105,11 @@ project:
 
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone git@github.com:WeTransfer/eslint-config-wetransfer.git
+   git clone git@github.com:WeTransfer/zip_tricks.git
    # Navigate to the newly cloned directory
-   cd eslint-config-wetransfer
+   cd zip_tricks
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream git@github.com:WeTransfer/eslint-config-wetransfer.git
+   git remote add upstream git@github.com:WeTransfer/zip_tricks.git
    ```
 
 2. If you cloned a while ago, get the latest changes from upstream:
@@ -127,10 +126,9 @@ project:
    git checkout -b <topic-branch-name>
    ```
 
-4. Commit your changes in logical chunks. Please adhere to these [AngularJS Git Commit Message Conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y)
-   or your code is unlikely be merged into the main project. Use Git's
-   [interactive rebase](https://help.github.com/articles/interactive-rebase)
-   feature to tidy up your commits before making them public.
+4. Commit your changes in logical chunks and/or squash them for readability and
+   conciseness. Check out [this post](https://chris.beams.io/posts/git-commit/) or
+   [this other post](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for some tips re: writing good commit messages.
 
 5. Locally merge (or rebase) the upstream development branch into your topic branch:
 
@@ -146,27 +144,6 @@ project:
 
 7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
     with a clear title and description.
-
-## Conventions of commit messages
-
-Adding features on repo
-
-```bash
-git commit -m "feat: message about this feature"
-```
-
-Fixing features on repo
-
-```bash
-git commit -m "fix: message about this update"
-```
-
-Removing features on repo
-
-```bash
-git commit -m "refactor: message about this" -m "BREAKING CHANGE: message about the breaking change"
-```
-
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to
 license your work under the same license as that used by the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,32 +10,30 @@ patches and features.
 
 ## What do I need to know to help?
 
-If you are looking to help to with a code contribution, the project uses Ruby. If you don't feel ready to make a code contribution yet, no problem -- keep an eye out on the issues page for issues tagged "good-first-issue" or "documentation-issue" -- or submit your own!
+If you are already familiar with the [Ruby Programming Language](https://www.ruby-lang.org/) you can start contributing code right away, otherwise look for issues labeled with *documentation* or *good first issue* to get started.
 
-If you are interested in making a code contribution and would like to learn more about the technologies that we use, check out the (non-exhaustive) list below. You can also get in touch with us via an issue or email and we can provide additional resources and information.
+If you are interested in contributing code and would like to learn more about the technologies that we use, check out the (non-exhaustive) list below. You can also get in touch with us via an issue or email to get additional information.
 
- - [ruby](https://ruby-doc.org/stdlib-2.4.1/) (currently tested to 2.4.1)
+ - [ruby](https://ruby-doc.org)
  - [rubyzip](https://github.com/rubyzip/rubyzip)
  - [rspec](http://rspec.info/) (for testing)
  - [zip files](https://en.wikipedia.org/wiki/Zip_(file_format))
 
-
-# How do I made a contribution?
+# How do I make a contribution?
 
 ## Using the issue tracker
 
 The issue tracker is the preferred channel for [bug reports](#bug-reports),
-[features requests](#feature-requests) and [submitting pull
+[feature requests](#feature-requests) and [submitting pull
 requests](#pull-requests), but please respect the following restrictions:
 
-* Please **do not** derail or troll issues. Keep the discussion on topic and
-  respect the opinions of others.
-
+* Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others. Adhere to the principles set out in the [Code of Conduct](https://github.com/WeTransfer/zip_tricks/blob/master/CODE_OF_CONDUCT.md).
 
 ## Bug reports
 
-A bug is a _demonstrable problem_ that is caused by the code in the repository.
-Good bug reports are extremely helpful - thank you!
+A bug is a _demonstrable problem_ that is caused by code in the repository.
+
+Good bug reports are extremely helpful-thank you!
 
 Guidelines for bug reports:
 
@@ -43,14 +41,14 @@ Guidelines for bug reports:
    reported.
 
 2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   latest `master` or development branch in the repository.
+   latest `master` branch in the repository.
 
 3. **Isolate the problem** &mdash; create a [reduced test
    case](http://css-tricks.com/reduced-test-cases/) and a live example.
 
 A good bug report shouldn't leave others needing to chase you up for more
 information. Please try to be as detailed as possible in your report. What is
-your environment? What steps will reproduce the issue? What browser(s) and OS
+your environment? What steps will reproduce the issue? What tool(s) or OS will
 experience the problem? What would you expect to be the outcome? All these
 details will help people to fix any potential bugs.
 
@@ -65,7 +63,7 @@ Example:
 > 2. This is the second step
 > 3. Further steps, etc.
 >
-> `<url>` - a link to the reduced test case, if possible
+> `<url>` - a link to the reduced test case, if possible. Feel free to use a [Gist](https://gist.github.com).
 >
 > Any other information you want to share that is relevant to the issue being
 > reported. This might include the lines of code that you have identified as
@@ -83,7 +81,7 @@ provide as much detail and context as possible.
 
 ## Pull requests
 
-Good pull requests - patches, improvements, new features - are a fantastic
+Good pull requests-patches, improvements, new features-are a fantastic
 help. They should remain focused in scope and avoid containing unrelated
 commits.
 
@@ -92,10 +90,13 @@ implementing features, refactoring code, porting to a different language),
 otherwise you risk spending a lot of time working on something that the
 project's developers might not want to merge into the project.
 
-Please adhere to the coding conventions used throughout a project (indentation,
+Please adhere to the coding conventions used throughout the project (indentation,
 accurate comments, etc.) and any other requirements (such as test coverage).
 
-The project uses Rubocop which can be run using `bundle exec rubocop -c .rubocop.yml`.
+The project uses Rubocop which can be run using `bundle exec rubocop`. The test
+suite can be run with `bundle exec rspec`. You are also encouraged to use the
+script in the `testing` directory to create test files that you can then verify
+with various zip/unzip utilities. Further instructions are [here](https://github.com/WeTransfer/zip_tricks/blob/master/testing/README_TESTING.md).  
 
 Follow this process if you'd like your work considered for inclusion in the
 project:
@@ -146,4 +147,5 @@ project:
     with a clear title and description.
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to
-license your work under the same license as that used by the project.
+license your work under the same license as that used by the project, which you
+can see by clicking [here](https://github.com/WeTransfer/zip_tricks/blob/master/LICENSE.txt). 


### PR DESCRIPTION
Not sure which emails we should list for contact purposes. Went with mine and @julik's for now. Also added a rudimentary set of contributor guidelines based on our [eslint config repo](https://github.com/WeTransfer/eslint-config-wetransfer). 

Closes #29. 