### PR TITLE
Allow to specify modification time when adding entries to streamer

### DIFF
--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -162,14 +162,17 @@ class ZipTricks::Streamer
   # Streamer, because otherwise it is impossible to know it's size upfront.
   #
   # @param filename [String] the name of the file in the entry
+  # @param modification_time [Time] the modification time of the file in the archive
   # @param compressed_size [Integer] the size of the compressed entry that
   #                                   is going to be written into the archive
   # @param uncompressed_size [Integer] the size of the entry when uncompressed, in bytes
   # @param crc32 [Integer] the CRC32 checksum of the entry when uncompressed
   # @param use_data_descriptor [Boolean] whether the entry body will be followed by a data descriptor
   # @return [Integer] the offset the output IO is at after writing the entry header
-  def add_deflated_entry(filename:, compressed_size: 0, uncompressed_size: 0, crc32: 0, use_data_descriptor: false)
-    add_file_and_write_local_header(filename: filename, crc32: crc32,
+  def add_deflated_entry(filename:, modification_time: Time.now.utc, compressed_size: 0, uncompressed_size: 0, crc32: 0, use_data_descriptor: false)
+    add_file_and_write_local_header(filename: filename,
+                                    modification_time: modification_time,
+                                    crc32: crc32,
                                     storage_mode: DEFLATED,
                                     compressed_size: compressed_size,
                                     uncompressed_size: uncompressed_size,
@@ -186,12 +189,14 @@ class ZipTricks::Streamer
   # times to write the actual contents of the body.
   #
   # @param filename [String] the name of the file in the entry
+  # @param modification_time [Time] the modification time of the file in the archive
   # @param size [Integer] the size of the file when uncompressed, in bytes
   # @param crc32 [Integer] the CRC32 checksum of the entry when uncompressed
   # @param use_data_descriptor [Boolean] whether the entry body will be followed by a data descriptor. When in use
   # @return [Integer] the offset the output IO is at after writing the entry header
-  def add_stored_entry(filename:, size: 0, crc32: 0, use_data_descriptor: false)
+  def add_stored_entry(filename:, modification_time: Time.now.utc,  size: 0, crc32: 0, use_data_descriptor: false)
     add_file_and_write_local_header(filename: filename,
+                                    modification_time: modification_time,
                                     crc32: crc32,
                                     storage_mode: STORED,
                                     compressed_size: size,
@@ -203,9 +208,11 @@ class ZipTricks::Streamer
   # Adds an empty directory to the archive with a size of 0 and permissions of 755.
   #
   # @param dirname [String] the name of the directory in the archive
+  # @param modification_time [Time] the modification time of the directory in the archive
   # @return [Integer] the offset the output IO is at after writing the entry header
-  def add_empty_directory(dirname:)
+  def add_empty_directory(dirname:, modification_time: Time.now.utc)
     add_file_and_write_local_header(filename: dirname.to_s + '/',
+                                    modification_time: modification_time,
                                     crc32: 0,
                                     storage_mode: STORED,
                                     compressed_size: 0,
@@ -246,10 +253,12 @@ class ZipTricks::Streamer
   # and attention is recommended.
   #
   # @param filename[String] the name of the file in the archive
+  # @param modification_time [Time] the modification time of the file in the archive
   # @yield [#<<, #write] an object that the file contents must be written to that will be automatically closed
   # @return [#<<, #write, #close] an object that the file contents must be written to, has to be closed manually
-  def write_stored_file(filename)
+  def write_stored_file(filename, modification_time: Time.now.utc)
     add_stored_entry(filename: filename,
+                     modification_time: modification_time,
                      use_data_descriptor: true,
                      crc32: 0,
                      size: 0)
@@ -296,9 +305,11 @@ class ZipTricks::Streamer
   # and attention is recommended.
   #
   # @param filename[String] the name of the file in the archive
+  # @param modification_time [Time] the modification time of the file in the archive
   # @yield [#<<, #write] an object that the file contents must be written to
-  def write_deflated_file(filename)
+  def write_deflated_file(filename, modification_time: Time.now.utc)
     add_deflated_entry(filename: filename,
+                       modification_time: modification_time,
                        use_data_descriptor: true,
                        crc32: 0,
                        compressed_size: 0,
@@ -390,6 +401,7 @@ class ZipTricks::Streamer
 
   def add_file_and_write_local_header(
 filename:,
+modification_time:,
 crc32:,
 storage_mode:,
 compressed_size:,
@@ -415,7 +427,7 @@ use_data_descriptor:)
                   compressed_size,
                   uncompressed_size,
                   storage_mode,
-                  Time.now.utc,
+                  modification_time,
                   use_data_descriptor)
 
     @files << e

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -496,4 +496,22 @@ describe ZipTricks::Streamer do
       'My.Super.file (1).txt.zip'
     ])
   end
+
+  it 'writes the specified modification time' do
+    fake_writer = double('Writer').as_null_object
+
+    expect(fake_writer).to receive(:write_local_file_header) { |**kwargs|
+      expect(kwargs[:mtime]).to eq(Time.new('2018-01-01 00:00:00'))
+    }.exactly(3).times
+
+    described_class.open(StringIO.new, writer: fake_writer) do |zip|
+      zip.write_stored_file('stored.txt', modification_time: Time.new('2018-01-01 00:00:00')) do |sink|
+        sink << 'stored'
+      end
+      zip.write_deflated_file('deflated.txt', modification_time: Time.new('2018-01-01 00:00:00')) do |sink|
+        sink << 'deflated'
+      end
+      zip.add_empty_directory(dirname: 'empty', modification_time: Time.new('2018-01-01 00:00:00'))
+    end
+  end
 end


### PR DESCRIPTION
Resolving #41. 

Added optional `modification_time` argument to all `add_*` and `write_*` streamer methods which is then passed to `add_file_and_write_local_header`.