### PR TITLE
Add Streamer#output_enum to support deferred writes

### DIFF
--- a/examples/deferred_write.rb
+++ b/examples/deferred_write.rb
@@ -5,42 +5,48 @@ require_relative '../lib/zip_tricks'
 # Using deferred writes (when you want to "pull" from a Streamer)
 # is also possible with ZipTricks.
 #
-# The RackBody class instead of Streamer is very useful for this
+# The OutputEnumerator class instead of Streamer is very useful for this
 # particular purpose. It does not start the archiving immediately,
 # but waits instead until you start pulling data out of it.
 #
-# Let's make a RackBody that writes a few files with random content. Note that when you create
+# Let's make a OutputEnumerator that writes a few files with random content. Note that when you create
 # that body it does not immediately write the ZIP:
-iterable = ZipTricks::RackBody.new do |zip|
+iterable = ZipTricks::Streamer.output_enum do |zip|
   (1..5).each do |i|
     zip.write_stored_file('random_%d04d.bin' % i) do |sink|
-      warn "Starting on file #{i}..."
+      warn "Starting on file #{i}...\n"
       sink << Random.new.bytes(1024)
     end
   end
 end
 
+$stderr.puts "\n\nOutput using #each"
+
 # Now we can treat the iterable as any Ruby enumerable object, since
 # it supports #each yielding every binary string output by the Streamer.
 # Only when we start using each() will the ZIP start generating. Just using
 # each() like we do here runs the archiving procedure to completion. See how
-# the output of the block within RackBody is interspersed with the stuff
+# the output of the block within OutputEnumerator is interspersed with the stuff
 # being yielded to each():
 iterable.each do |_binary_string|
   $stderr << '.'
 end
 
+$stderr.puts "\n\nOutput Enumerator returned from #each"
+
 # We now have output the entire archive, so using each() again
 # will restart the block we gave it. For example, we can user
 # an Enumerator - via enum_for - to "take" chunks of output when
 # we find necessary:
-enum = iterable.enum_for(:each)
+enum = iterable.each
 15.times do
   _bin_str = enum.next  # Obtain the subsequent chunk of the ZIP
   $stderr << '*'
 end
 
 # ... or a Fiber
+
+$stderr.puts "\n\nOutput using a Fiber"
 fib = Fiber.new do
   iterable.each do |binary_string|
     $stderr << '•'

--- a/examples/deferred_write.rb
+++ b/examples/deferred_write.rb
@@ -20,7 +20,7 @@ iterable = ZipTricks::Streamer.output_enum do |zip|
   end
 end
 
-$stderr.puts "\n\nOutput using #each"
+warn "\n\nOutput using #each"
 
 # Now we can treat the iterable as any Ruby enumerable object, since
 # it supports #each yielding every binary string output by the Streamer.
@@ -32,7 +32,7 @@ iterable.each do |_binary_string|
   $stderr << '.'
 end
 
-$stderr.puts "\n\nOutput Enumerator returned from #each"
+warn "\n\nOutput Enumerator returned from #each"
 
 # We now have output the entire archive, so using each() again
 # will restart the block we gave it. For example, we can user
@@ -46,7 +46,7 @@ end
 
 # ... or a Fiber
 
-$stderr.puts "\n\nOutput using a Fiber"
+warn "\n\nOutput using a Fiber"
 fib = Fiber.new do
   iterable.each do |binary_string|
     $stderr << '•'

--- a/examples/rack_application.rb
+++ b/examples/rack_application.rb
@@ -36,7 +36,7 @@ class ZipDownload
 
     # Create a suitable Rack response body, that will support each(),
     # close() and all the other methods. We can then return it up the stack.
-    zip_response_body = ZipTricks::RackBody.new do |zip|
+    zip_response_body = ZipTricks::Streamer.output_enum do |zip|
       begin
         # We are adding only one file to the ZIP here, but you could do that
         # with an arbitrary number of files of course.

--- a/lib/zip_tricks/block_write.rb
+++ b/lib/zip_tricks/block_write.rb
@@ -39,9 +39,4 @@ class ZipTricks::BlockWrite
     @block.call(encoded)
     self
   end
-
-  # Does nothing
-  def close
-    nil
-  end
 end

--- a/lib/zip_tricks/block_write.rb
+++ b/lib/zip_tricks/block_write.rb
@@ -20,7 +20,8 @@ class ZipTricks::BlockWrite
   # Every time this object gets written to, call the Rack body each() block
   # with the bytes given instead.
   def <<(buf)
-    return if buf.nil?
+    # Zero-size output has a special meaning  when using chunked encoding
+    return if buf.nil? || buf.bytesize.zero?
 
     # Ensure we ALWAYS write in binary encoding.
     encoded =
@@ -34,10 +35,6 @@ class ZipTricks::BlockWrite
       else
         buf
       end
-
-    #  buf.dup.force_encoding(Encoding::BINARY)
-    # Zero-size output has a special meaning  when using chunked encoding
-    return if encoded.bytesize.zero?
 
     @block.call(encoded)
     self

--- a/lib/zip_tricks/output_enumerator.rb
+++ b/lib/zip_tricks/output_enumerator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Can be used as a Rack response body directly. Will yield
+# a {ZipTricks::Streamer} for adding entries to the archive and writing
+# zip entry bodies.
+class ZipTricks::OutputEnumerator
+  # Prepares a new Rack response body with a Zip output stream.
+  # The block given to the constructor will be called when the response
+  # body will be read by the webserver, and will receive a {ZipTricks::Streamer}
+  # as it's block argument. You can then add entries to the Streamer as usual.
+  # The archive will be automatically closed at the end of the block.
+  #
+  #     # Precompute the Content-Length ahead of time
+  #     content_length = ZipTricks::SizeEstimator.estimate do | estimator |
+  #       estimator.add_stored_entry(filename: 'large.tif', size: 1289894)
+  #     end
+  #
+  #     # Prepare the response body. 
+  #     # The block will only be called when the
+  #     # response starts to be written.
+  #     body = ZipTricks::OutputEnumerator.new do | streamer |
+  #       streamer.add_stored_entry(filename: 'large.tif', size: 1289894, crc32: 198210)
+  #       streamer << large_file.read(1024*1024) until large_file.eof?
+  #       ...
+  #     end
+  #
+  #     return [200, {'Content-Type' => 'binary/octet-stream',
+  #     'Content-Length' => content_length.to_s}, body]
+  def initialize(**streamer_options, &blk)
+    @streamer_options = streamer_options.to_h
+    @archiving_block = blk
+  end
+
+  # Executes the block given to the constructor with a {ZipTricks::Streamer}
+  # and passes each written chunk to the block given to the method. This allows one
+  # to "take" output of the ZIP piecewise.
+  def each
+    if block_given?
+      block_write = ZipTricks::BlockWrite.new {|chunk| yield(chunk) }
+      ZipTricks::Streamer.open(block_write, **@streamer_options, &@archiving_block)
+    else
+      enum_for(:each)
+    end
+  end
+end

--- a/lib/zip_tricks/output_enumerator.rb
+++ b/lib/zip_tricks/output_enumerator.rb
@@ -15,7 +15,7 @@ class ZipTricks::OutputEnumerator
   #       estimator.add_stored_entry(filename: 'large.tif', size: 1289894)
   #     end
   #
-  #     # Prepare the response body. 
+  #     # Prepare the response body.
   #     # The block will only be called when the
   #     # response starts to be written.
   #     body = ZipTricks::OutputEnumerator.new do | streamer |
@@ -36,7 +36,7 @@ class ZipTricks::OutputEnumerator
   # to "take" output of the ZIP piecewise.
   def each
     if block_given?
-      block_write = ZipTricks::BlockWrite.new {|chunk| yield(chunk) }
+      block_write = ZipTricks::BlockWrite.new { |chunk| yield(chunk) }
       ZipTricks::Streamer.open(block_write, **@streamer_options, &@archiving_block)
     else
       enum_for(:each)

--- a/lib/zip_tricks/rack_body.rb
+++ b/lib/zip_tricks/rack_body.rb
@@ -1,44 +1,7 @@
 # frozen_string_literal: true
 
-# Can be used as a Rack response body directly. Will yield
-# a {ZipTricks::Streamer} for adding entries to the archive and writing
-# zip entry bodies.
-class ZipTricks::RackBody
-  # Prepares a new Rack response body with a Zip output stream.
-  # The block given to the constructor will be called when the response
-  # body will be read by the webserver, and will receive a {ZipTricks::Streamer}
-  # as it's block argument. You can then add entries to the Streamer as usual.
-  # The archive will be automatically closed at the end of the block.
-  #
-  #     # Precompute the Content-Length ahead of time
-  #     content_length = ZipTricks::SizeEstimator.estimate do | estimator |
-  #       estimator.add_stored_entry(filename: 'large.tif', size: 1289894)
-  #     end
-  #
-  #     # Prepare the response body. The block will only be called when the
-  #       response starts to be written.
-  #     body = ZipTricks::RackBody.new do | streamer |
-  #       streamer.add_stored_entry(filename: 'large.tif', size: 1289894, crc32: 198210)
-  #       streamer << large_file.read(1024*1024) until large_file.eof?
-  #       ...
-  #     end
-  #
-  #     return [200, {'Content-Type' => 'binary/octet-stream',
-  #     'Content-Length' => content_length.to_s}, body]
-  def initialize(&blk)
-    @archiving_block = blk
-  end
-
-  # Connects a {ZipTricks::BlockWrite} to the Rack webserver output,
-  # and calls the proc given to the constructor with a {ZipTricks::Streamer}
-  # for archive writing.
-  def each(&body_chunk_block)
-    fake_io = ZipTricks::BlockWrite.new(&body_chunk_block)
-    ZipTricks::Streamer.open(fake_io, &@archiving_block)
-  end
-
-  # Does nothing because nothing has to be deallocated or canceled
-  # even if the zip output is incomplete. The archive gets closed
-  # automatically as part of {ZipTricks::Streamer.open}
+# Deprecated
+class ZipTricks::RackBody < ZipTricks::OutputEnumerator
   def close; end
 end
+

--- a/lib/zip_tricks/rack_body.rb
+++ b/lib/zip_tricks/rack_body.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Deprecated
+# RackBody is actually just another use of the OutputEnumerator, since a Rack body
+# object must support `#each` yielding successive binary strings.
 class ZipTricks::RackBody < ZipTricks::OutputEnumerator
-  def close; end
 end

--- a/lib/zip_tricks/rack_body.rb
+++ b/lib/zip_tricks/rack_body.rb
@@ -4,4 +4,3 @@
 class ZipTricks::RackBody < ZipTricks::OutputEnumerator
   def close; end
 end
-

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -129,9 +129,8 @@ class ZipTricks::Streamer
   #       ...
   #     end
   #
-  # @param stream [IO] the destination IO for the ZIP (should respond to `tell` and `<<`)
   # @param kwargs_for_new [Hash] keyword arguments for {Streamer.new}
-  # @yield [Streamer] the streamer that can be written to
+  # @return [Enumerator] the enumerator you can read bytestrings of the ZIP from using `each`
   def self.output_enum(**kwargs_for_new, &zip_streamer_block)
     ZipTricks::OutputEnumerator.new(**kwargs_for_new, &zip_streamer_block)
   end

--- a/spec/zip_tricks/block_write_spec.rb
+++ b/spec/zip_tricks/block_write_spec.rb
@@ -34,10 +34,6 @@ describe ZipTricks::BlockWrite do
     expect(accum_string.bytesize).to eq(1_054)
   end
 
-  it 'can be closed' do
-    expect(described_class.new {}.close).to be_nil
-  end
-
   it 'forces the written strings to binary encoding' do
     blobs = []
     adapter = described_class.new { |s| blobs << s }

--- a/spec/zip_tricks/output_enumerator_spec.rb
+++ b/spec/zip_tricks/output_enumerator_spec.rb
@@ -65,5 +65,4 @@ describe ZipTricks::OutputEnumerator do
     expect(per_filename).to have_key('A file')
     expect(per_filename['A file'].bytesize).to eq(file_body.bytesize)
   end
-
 end

--- a/spec/zip_tricks/output_enumerator_spec.rb
+++ b/spec/zip_tricks/output_enumerator_spec.rb
@@ -1,0 +1,69 @@
+require_relative '../spec_helper'
+
+describe ZipTricks::OutputEnumerator do
+  it 'returns parts of the ZIP file when called via #each with immediate yield' do
+    output_buf = Tempfile.new('output')
+
+    file_body = Random.new.bytes(1024 * 1024 + 8981)
+
+    body = described_class.new do |zip|
+      zip.add_stored_entry(filename: 'A file',
+                           size: file_body.bytesize,
+                           crc32: Zlib.crc32(file_body))
+      zip << file_body
+    end
+
+    body.each do |some_data|
+      output_buf << some_data
+    end
+
+    output_buf.rewind
+    expect(output_buf.size).to eq(1_057_714)
+
+    per_filename = {}
+    Zip::File.open(output_buf.path) do |zip_file|
+      # Handle entries one by one
+      zip_file.each do |entry|
+        # The entry name gets returned with a binary encoding, we have to force it back.
+        per_filename[entry.name] = entry.get_input_stream.read
+      end
+    end
+
+    expect(per_filename).to have_key('A file')
+    expect(per_filename['A file'].bytesize).to eq(file_body.bytesize)
+  end
+
+  it 'returns parts of the ZIP file when called using an Enumerator' do
+    output_buf = Tempfile.new('output')
+
+    file_body = Random.new.bytes(1024 * 1024 + 8981)
+
+    body = described_class.new do |zip|
+      zip.add_stored_entry(filename: 'A file',
+                           size: file_body.bytesize,
+                           crc32: Zlib.crc32(file_body))
+      zip << file_body
+    end
+
+    enum = body.each
+    enum.each do |some_data|
+      output_buf << some_data
+    end
+
+    output_buf.rewind
+    expect(output_buf.size).to eq(1_057_714)
+
+    per_filename = {}
+    Zip::File.open(output_buf.path) do |zip_file|
+      # Handle entries one by one
+      zip_file.each do |entry|
+        # The entry name gets returned with a binary encoding, we have to force it back.
+        per_filename[entry.name] = entry.get_input_stream.read
+      end
+    end
+
+    expect(per_filename).to have_key('A file')
+    expect(per_filename['A file'].bytesize).to eq(file_body.bytesize)
+  end
+
+end

--- a/spec/zip_tricks/rack_body_spec.rb
+++ b/spec/zip_tricks/rack_body_spec.rb
@@ -16,7 +16,6 @@ describe ZipTricks::RackBody do
     body.each do |some_data|
       output_buf << some_data
     end
-    body.close
 
     output_buf.rewind
     expect(output_buf.size).to eq(1_057_714)


### PR DESCRIPTION
The pattern that is required for output of ZIPs from Rack and the pattern for deferred output (see #45 ) are actually the same. All we need to do to facilitate both is to provide an eachable enumerator for the output, so that the calling code can have control.

This PR strips the RackBody to the minimum and replaces it with a more generic output enumerator object that supports this usage pattern. I also removed some `#close` methods which were no-ops anyway, so a major version bump will probably be in order to support this.