### PR TITLE
Facilitate usage with nginx by hinting it to disable buffering

### DIFF
--- a/lib/zip_tricks/rails_streaming.rb
+++ b/lib/zip_tricks/rails_streaming.rb
@@ -8,7 +8,10 @@ module ZipTricks::RailsStreaming
   # the Rails response stream is going to be closed automatically.
   # @yield [Streamer] the streamer that can be written to
   def zip_tricks_stream
+    # Set a reasonable content type
     response.headers['Content-Type'] = 'application/zip'
+    # Make sure nginx buffering is suppressed - see https://github.com/WeTransfer/zip_tricks/issues/48
+    response.headers['X-Accel-Buffering'] = 'no'
     # Create a wrapper for the write call that quacks like something you
     # can << to, used by ZipTricks
     w = ZipTricks::BlockWrite.new { |chunk| response.stream.write(chunk) }

--- a/spec/zip_tricks/rails_streaming_spec.rb
+++ b/spec/zip_tricks/rails_streaming_spec.rb
@@ -23,6 +23,7 @@ describe ZipTricks::RailsStreaming do
     response = ctr.response
 
     expect(response.headers['Content-Type']).to eq('application/zip')
+    expect(response.headers['X-Accel-Buffering']).to eq('no')
     output_stream = response.stream
     expect(output_stream).to be_closed
     expect(output_stream.string).not_to be_empty


### PR DESCRIPTION
By default nginx will buffer the response and then send it onwards. If the ZIP takes a long time to generate nginx effectively times out the app and sends whatever it managed to receive from the app onwards to the client. We need to tell nginx that this endpoint is long-polling/streaming so that it does not abort prematurely.