### PR TITLE
Bump rubyzip version for CVE-2018-1000544 mitigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.7.1
+
+* Bump rubyzip to 1.2.2 to mitigate CVE-2018-1000544
+
 ## 4.7.0
 
 * Replace `RackBody` with `OutputEnumerator` since we want to provide a generic way of deferring ZIP output, also when using enumerators.
@@ -8,7 +12,7 @@
 
 * Add `mtime:` option to all Streamer methods for adding files and directories, to permit setting modification time per-entry
 * Optimize EOCD signature lookup when reading archives
-* Reformat using the [we_transfer_style](https://rubygems.org/gems/we_transfer_style) Rubocop rules and conventions 
+* Reformat using the [we_transfer_style](https://rubygems.org/gems/we_transfer_style) Rubocop rules and conventions
 * Add code of conduct and contribution guidelines
 * Reduce the size of the CRC32 buffer to 64KB (backed by a benchmark), extract buffering into a wrapper proxy
 

--- a/lib/zip_tricks/version.rb
+++ b/lib/zip_tricks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipTricks
-  VERSION = '4.7.0'
+  VERSION = '4.7.1'
 end

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1'
-  spec.add_development_dependency 'rubyzip', '~> 1.1'
+  spec.add_development_dependency 'rubyzip', '>= 1.2.2'
   spec.add_development_dependency 'terminal-table'
   spec.add_development_dependency 'range_utils'
 


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2018-1000544

So long as we make sure we're always at or higher than v1.2.2 of rubyzip we should be covered, since the vulnerability affects 1.2.1 and below.