### PR TITLE
Use correct variable in RemoteUncap#request_object_size

### DIFF
--- a/lib/zip_tricks/remote_uncap.rb
+++ b/lib/zip_tricks/remote_uncap.rb
@@ -43,6 +43,6 @@ class ZipTricks::RemoteUncap
   # @return [Fixnum] the byte size of the ranged request
   def request_object_size
     http = Net::HTTP.start(@uri.hostname, @uri.port)
-    http.request_head(uri)['Content-Length'].to_i
+    http.request_head(@uri)['Content-Length'].to_i
   end
 end

--- a/spec/zip_tricks/remote_uncap_spec.rb
+++ b/spec/zip_tricks/remote_uncap_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'net/http'
 
 describe ZipTricks::RemoteUncap, webmock: true do
   let(:uri) { URI.parse('http://example.com/file.zip') }
@@ -110,5 +111,19 @@ describe ZipTricks::RemoteUncap, webmock: true do
     expect(second.uncompressed_size).to eq(payload2.size)
     readable_zip.seek(second.compressed_data_offset, IO::SEEK_SET)
     expect(readable_zip.read(12)).to eq(payload2.read(12))
+  end
+
+  describe '#request_object_size' do
+    let(:net_http) { double }
+
+    before do
+      allow(Net::HTTP).to receive(:start).and_return(net_http)
+    end
+
+    it 'makes a HEAD request for the uri' do
+      subject = described_class.new(uri)
+      expect(net_http).to receive(:request_head).with(a_kind_of(URI)).and_return("Content-Length" => "100")
+      subject.request_object_size
+    end
   end
 end


### PR DESCRIPTION
Use instance variable, otherwise things go 💥 