### PR TITLE
Optimize CRC32 allocations for IOs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,4 @@ Style/GlobalVars:
   Exclude:
       - qa/*.rb
       - spec/spec_helper.rb
+      - spec/support/zip_inspection.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.7.4
+
+* Use a single fixed capacity string in StreamCRC32.from_io to avoid unnecessary allocations
+
 ## 4.7.3
 
 * Fix RemoteUncap#request_object_size to function correctly

--- a/lib/zip_tricks/stream_crc32.rb
+++ b/lib/zip_tricks/stream_crc32.rb
@@ -2,13 +2,26 @@
 
 # A simple stateful class for keeping track of a CRC32 value through multiple writes
 class ZipTricks::StreamCRC32
+  STRINGS_HAVE_CAPACITY_SUPPORT = begin
+    String.new('', capacity: 1)
+    true
+  rescue ArgumentError
+    false
+  end
+  CRC_BUF_SIZE = 1024 * 512
+  private_constant :STRINGS_HAVE_CAPACITY_SUPPORT, :CRC_BUF_SIZE
+
   # Compute a CRC32 value from an IO object. The object should respond to `read` and `eof?`
   #
   # @param io[IO] the IO to read the data from
   # @return [Fixnum] the computed CRC32 value
   def self.from_io(io)
+    # If we can specify the string capacity upfront we will not have to resize
+    # the string during operation. This saves time but is only available on
+    # recent Ruby 2.x versions.
+    blob = STRINGS_HAVE_CAPACITY_SUPPORT ? String.new('', capacity: CRC_BUF_SIZE) : String.new('')
     crc = new
-    crc << io.read(1024 * 512) until io.eof?
+    crc << io.read(CRC_BUF_SIZE, blob) until io.eof?
     crc.to_i
   end
 

--- a/lib/zip_tricks/version.rb
+++ b/lib/zip_tricks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipTricks
-  VERSION = '4.7.3'
+  VERSION = '4.7.4'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,71 +7,11 @@ require 'digest'
 require 'fileutils'
 require 'shellwords'
 require 'zip'
-require 'delegate'
 
-class ReadMonitor < SimpleDelegator
-  def read(*)
-    super.tap do
-      @num_reads ||= 0
-      @num_reads += 1
-    end
-  end
-
-  def num_reads
-    @num_reads || 0
-  end
-end
-
-class ManagedTempfile < Tempfile
-  @@managed_tempfiles = []
-
-  def initialize(*)
-    super
-    @@managed_tempfiles << self
-  end
-
-  def self.prune!
-    @@managed_tempfiles.each do |tf|
-      begin
-        tf.close
-        tf.unlink
-      rescue
-        nil
-      end
-    end
-    @@managed_tempfiles.clear
-  end
-end
-
-module ZipInspection
-  def inspect_zip_with_external_tool(path_to_zip)
-    zipinfo_path = 'zipinfo'
-    $zip_inspection_buf ||= StringIO.new
-    $zip_inspection_buf.puts "\n"
-    # The only way to get at the RSpec example without using the block argument
-    $zip_inspection_buf.puts "Inspecting ZIP output of #{inspect}."
-    $zip_inspection_buf.puts 'Be aware that the zipinfo version on OSX is too \
-                              old to deal with Zip64.'
-    escaped_cmd = Shellwords.join([zipinfo_path, '-tlhvz', path_to_zip])
-    $zip_inspection_buf.puts `#{escaped_cmd}`
-  end
-
-  def open_with_external_app(app_path, path_to_zip, skip_if_missing)
-    bin_exists = File.exist?(app_path)
-    skip "This system does not have #{File.basename(app_path)}" if skip_if_missing && !bin_exists
-    return unless bin_exists
-    `#{Shellwords.join([app_path, path_to_zip])}`
-  end
-
-  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: false)
-    # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
-    # not perform any checks on the files since we do not really know where they are on disk.
-    # Visual inspection should show whether the unarchiving is handled correctly.
-    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/ \
-              Contents/MacOS/Archive Utility'
-    open_with_external_app(au_path, path_to_zip, skip_if_missing)
-  end
-end
+require_relative 'support/read_monitor'
+require_relative 'support/managed_tempfile'
+require_relative 'support/zip_inspection'
+require_relative 'support/allocate_under_matcher'
 
 RSpec.configure do |config|
   config.include ZipInspection

--- a/spec/support/allocate_under_matcher.rb
+++ b/spec/support/allocate_under_matcher.rb
@@ -1,0 +1,27 @@
+require 'allocation_stats'
+RSpec::Matchers.define :allocate_under do |expected|
+  match do |actual|
+    @trace = actual.is_a?(Proc) ? AllocationStats.trace(&actual) : actual
+    @trace.new_allocations.size < expected
+  end
+
+  def objects
+    self
+  end
+
+  def supports_block_expectations?
+    true
+  end
+
+  def output_trace_info(trace)
+    trace.allocations(alias_paths: true).group_by(:sourcefile, :sourceline, :class).to_text
+  end
+
+  failure_message do |_actual|
+    "expected under #{expected} objects to be allocated; got #{@trace.new_allocations.size}:\n\n" << output_trace_info(@trace)
+  end
+
+  description do
+    "allocates under #{expected} objects"
+  end
+end

--- a/spec/support/managed_tempfile.rb
+++ b/spec/support/managed_tempfile.rb
@@ -1,0 +1,20 @@
+class ManagedTempfile < Tempfile
+  @@managed_tempfiles = []
+
+  def initialize(*)
+    super
+    @@managed_tempfiles << self
+  end
+
+  def self.prune!
+    @@managed_tempfiles.each do |tf|
+      begin
+        tf.close
+        tf.unlink
+      rescue
+        nil
+      end
+    end
+    @@managed_tempfiles.clear
+  end
+end

--- a/spec/support/read_monitor.rb
+++ b/spec/support/read_monitor.rb
@@ -1,0 +1,14 @@
+require 'delegate'
+
+class ReadMonitor < SimpleDelegator
+  def read(*)
+    super.tap do
+      @num_reads ||= 0
+      @num_reads += 1
+    end
+  end
+
+  def num_reads
+    @num_reads || 0
+  end
+end

--- a/spec/support/zip_inspection.rb
+++ b/spec/support/zip_inspection.rb
@@ -1,0 +1,29 @@
+module ZipInspection
+  def inspect_zip_with_external_tool(path_to_zip)
+    zipinfo_path = 'zipinfo'
+    $zip_inspection_buf ||= StringIO.new
+    $zip_inspection_buf.puts "\n"
+    # The only way to get at the RSpec example without using the block argument
+    $zip_inspection_buf.puts "Inspecting ZIP output of #{inspect}."
+    $zip_inspection_buf.puts 'Be aware that the zipinfo version on OSX is too \
+                              old to deal with Zip64.'
+    escaped_cmd = Shellwords.join([zipinfo_path, '-tlhvz', path_to_zip])
+    $zip_inspection_buf.puts `#{escaped_cmd}`
+  end
+
+  def open_with_external_app(app_path, path_to_zip, skip_if_missing)
+    bin_exists = File.exist?(app_path)
+    skip "This system does not have #{File.basename(app_path)}" if skip_if_missing && !bin_exists
+    return unless bin_exists
+    `#{Shellwords.join([app_path, path_to_zip])}`
+  end
+
+  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: false)
+    # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
+    # not perform any checks on the files since we do not really know where they are on disk.
+    # Visual inspection should show whether the unarchiving is handled correctly.
+    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/ \
+              Contents/MacOS/Archive Utility'
+    open_with_external_app(au_path, path_to_zip, skip_if_missing)
+  end
+end

--- a/spec/zip_tricks/stream_crc32_spec.rb
+++ b/spec/zip_tricks/stream_crc32_spec.rb
@@ -11,7 +11,12 @@ describe ZipTricks::StreamCRC32 do
 
   it 'when computing the CRC32 from an IO only allocates one String' do
     raw = StringIO.new(Random.new.bytes(45 * 1024 * 1024))
-    expect { described_class.from_io(raw) }.to allocate_under(3).objects
+    # The number of objects allocated depends on the MRI version, but in
+    # all cases there is only one String allocated. We work in blocks
+    # of 512KB so if we allocate a String for each read() - which is
+    # what this spec tries to prevent - we would certainly go over
+    # 90 allocations.
+    expect { described_class.from_io(raw) }.to allocate_under(10).objects
   end
 
   it 'allows in-place updates' do

--- a/spec/zip_tricks/stream_crc32_spec.rb
+++ b/spec/zip_tricks/stream_crc32_spec.rb
@@ -9,6 +9,11 @@ describe ZipTricks::StreamCRC32 do
     expect(via_from_io).to eq(crc)
   end
 
+  it 'when computing the CRC32 from an IO only allocates one String' do
+    raw = StringIO.new(Random.new.bytes(45 * 1024 * 1024))
+    expect { described_class.from_io(raw) }.to allocate_under(3).objects
+  end
+
   it 'allows in-place updates' do
     raw = StringIO.new(Random.new.bytes(45 * 1024 * 1024))
     crc = Zlib.crc32(raw.string)

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'complexity_assert'
   spec.add_development_dependency 'coderay'
   spec.add_development_dependency 'benchmark-ips'
+  spec.add_development_dependency 'allocation_stats', '~> 0.1.5'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'wetransfer_style', '0.6.0'
 end


### PR DESCRIPTION
We can reuse a string buffer across multiple reads, thereby
reducing allocations and GC churn. Also we can raise the
buffer size as reading the file is usually more expensive than
computing the CRC. And to top it off on recent Rubies we can
pre-cap our String to the right size and it will not have to
be resized on every alteration, sparing cycles. It uses two
semi-obscure features:

**Capacity preallocation**

The constructor for `String` accepts an optional `capacity`
keyword argument, since
https://bugs.ruby-lang.org/issues/12024 The argument can be
used to pre-size the String to the specific number of bytes.
If the string gets mutated, and the new string contents is not
larger than the `capacity` of the string, the string will not
need resizing - meaning we never need to realloc for the
string contents. We must run on older Rubies too so that
optimization is conditional.

**IO#read with the buffer argument**

All `IO#read` calls accept an optional `outbuf` argument which
should be a String. IO then replaces the contents of that
string instead of allocating a new one, and returns it. This
makes it possible to reuse one and the same string object
throughout multiple `read` calls. See
https://apidock.com/ruby/IO/read for more. Since we only read
as many bytes as we set in `capacity`, we won't be resizing
the string either.

We use a larger buffer size as this method has different
characteristics than the one we use for stream-writes from
the Streamer.

**Benchmarks**

https://gist.github.com/julik/ada7229c8d85290aad3c72572c368f01
