### PR TITLE
Add directory/file clobber check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 inherit_gem:
   wetransfer_style: ruby/default.yml
+AllCops:
+  TargetRubyVersion: 2.1
 Layout/FirstMethodArgumentLineBreak:
   Enabled: false
 Layout/FirstMethodParameterLineBreak:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.8.0
+
+* Make sure that when directories clobber files and vice versa we raise a clear error. Add `PathSet` which keeps track of entries
+  and all the directories needed to create them, document `PathSet`
+* Move the `uniquify_filenames` function into a module for easier removal later
+* Add the `auto_rename_duplicate_filenames` parameter to `Streamer` constructor. We need to make this optional
+  because making filenames unique can be very tricky when subdirectories are involved, and strictly
+  speaking we should not be applying this transformation at all - there should be no output of
+  duplicate filenames by the caller. So making the filenames should be available, but optional.
+
 ## 4.7.4
 
 * Use a single fixed capacity string in StreamCRC32.from_io to avoid unnecessary allocations

--- a/lib/zip_tricks/path_set.rb
+++ b/lib/zip_tricks/path_set.rb
@@ -1,0 +1,148 @@
+# rubocop:disable Layout/IndentHeredoc
+
+# A ZIP archive contains a flat list of entries. These entries can implicitly
+# create directories when the archive is expanded. For example, an entry with
+# the filename of "some folder/file.docx" will make the unarchiving application
+# create a directory called "some folder" automatically, and then deposit the
+# file "file.docx" in that directory. These "implicit" directories can be
+# arbitrarily nested, and create a tree structure of directories. That structure
+# however is implicit as the archive contains a flat list.
+#
+# This creates opportunities for conflicts. For example, imagine the following
+# structure:
+#
+# * `something/` - specifies an empty directory with the name "something"
+# * `something` - specifies a file, creates a conflict
+#
+# This can be prevented with filename uniqueness checks. It does get funkier however
+# as the rabbit hole goes down:
+#
+# * `dir/subdir/another_subdir/yet_another_subdir/file.bin` - declares a file and directories
+# * `dir/subdir/another_subdir/yet_another_subdir` - declares a file at one of the levels, creates a conflict
+#
+# The results of this ZIP structure aren't very easy to predict as they depend on the
+# application that opens the archive. For example, BOMArchiveHelper on macOS will expand files
+# as they are declared in the ZIP, but once a conflict occurs it will fail with "error -21". It
+# is not very transparent to the user why unarchiving fails, and it has to - and can reliably - only
+# be prevented when the archive gets created.
+#
+# Unfortunately that conflicts with another "magical" feature of ZipTricks which automatically
+# "fixes" duplicate filenames - filenames (paths) which have already been added to the archive.
+# This fix is performed by appending (1), then (2) and so forth to the filename so that the
+# conflict is avoided. This is not possible to apply to directories, because when one of the
+# path components is reused in multiple filenames it means those entities should end up in
+# the same directory (subdirectory) once the archive is opened.
+class ZipTricks::PathSet
+  class Conflict < StandardError
+  end
+
+  class FileClobbersDirectory < Conflict
+  end
+
+  class DirectoryClobbersFile < Conflict
+  end
+
+  def initialize
+    @known_directories = Set.new
+    @known_files = Set.new
+  end
+
+  # Adds a directory path to the set of known paths, including
+  # all the directories that contain it. So, calling
+  #    add_directory_path("dir/dir2/dir3")
+  # will add "dir", "dir/dir2", "dir/dir2/dir3".
+  #
+  # @param path[String] the path to the directory to add
+  # @return [void]
+  def add_directory_path(path)
+    path_and_ancestors(path).each do |parent_directory_path|
+      if @known_files.include?(parent_directory_path)
+        # Have to use the old-fashioned heredocs because ZipTricks
+        # aims to be compatible with MRI 2.1+ syntax, and squiggly
+        # heredoc is only available starting 2.3+
+        error_message = <<ERR
+The path #{parent_directory_path.inspect} which has to be added
+as a directory is already used for a file.
+
+The directory at this path would get created implicitly
+to produce #{path.inspect} during decompresison.
+
+This would make some archive utilities refuse to open
+the ZIP.
+ERR
+        raise DirectoryClobbersFile, error_message
+      end
+      @known_directories << parent_directory_path
+    end
+  end
+
+  # Adds a file path to the set of known paths, including
+  # all the directories that contain it. Once a file has been added,
+  # it is no longer possible to add a directory having the same path
+  # as this would cause conflict.
+  #
+  # The operation also adds all the containing directories for the file, so
+  #    add_file_path("dir/dir2/file.doc")
+  # will add "dir" and "dir/dir2" as directories, "dir/dir2/dir3".
+  #
+  # @param file_path[String] the path to the directory to add
+  # @return [void]
+  def add_file_path(file_path)
+    if @known_files.include?(file_path)
+      error_message = <<ERR
+The file at #{file_path.inspect} has already been included
+in the archive. Adding it the second time would cause
+the first file to be overwritten during unarchiving, and
+could also get the archive flagged as invalid.
+ERR
+      raise Conflict, error_message
+    end
+
+    if @known_directories.include?(file_path)
+      error_message = <<ERR
+The path #{file_path.inspect} is already used for
+a directory, but you are trying to add it as a file.
+
+This would make some archive utilities refuse
+to open the ZIP.
+ERR
+      raise FileClobbersDirectory, error_message
+    end
+
+    # Add all the directories which this file is contained in
+    *dir_components, _file_name = non_empty_path_components(file_path)
+    add_directory_path(dir_components.join('/'))
+
+    # ...and then the file itself
+    @known_files << file_path
+  end
+
+  # Tells whether a specific full path is already known to the PathSet.
+  # Can be a path for a directory or for a file.
+  #
+  # @param path_in_archive[String] the path to check for inclusion
+  # @return [Boolean]
+  def include?(path_in_archive)
+    @known_files.include?(path_in_archive) || @known_directories.include?(path_in_archive)
+  end
+
+  # Clears the contained sets
+  # @return [void]
+  def clear
+    @known_files.clear
+    @known_directories.clear
+  end
+
+  private
+
+  def non_empty_path_components(path)
+    path.split('/').reject(&:empty?)
+  end
+
+  def path_and_ancestors(path)
+    path_components = non_empty_path_components(path)
+    path_components.each_with_object([]) do |component, seen|
+      seen << [seen.last, component].compact.join('/')
+    end
+  end
+end

--- a/lib/zip_tricks/size_estimator.rb
+++ b/lib/zip_tricks/size_estimator.rb
@@ -20,10 +20,11 @@ class ZipTricks::SizeEstimator
   #               uncompressed_size: 89281911, compressed_size: 121908)
   #     end
   #
+  # @param kwargs_for_streamer_new Any options to pass to Streamer, see {Streamer#initialize}
   # @return [Integer] the size of the resulting archive, in bytes
   # @yield [SizeEstimator] the estimator
-  def self.estimate
-    streamer = ZipTricks::Streamer.new(ZipTricks::NullWriter)
+  def self.estimate(**kwargs_for_streamer_new)
+    streamer = ZipTricks::Streamer.new(ZipTricks::NullWriter, **kwargs_for_streamer_new)
     estimator = new(streamer)
     yield(estimator)
     streamer.close # Returns the .tell of the contained IO

--- a/lib/zip_tricks/uniquify_filename.rb
+++ b/lib/zip_tricks/uniquify_filename.rb
@@ -1,0 +1,38 @@
+module ZipTricks::UniquifyFilename
+
+  # Makes a given filename unique by appending a (n) suffix
+  # between just before the filename extension. So "file.txt" gets
+  # transformed into "file (1).txt". The transformation is applied
+  # repeatedly as long as the generated filename is present
+  # in `while_included_in` object
+  #
+  # @param path[String] the path to make unique
+  # @param while_included_in[#include?] an object that stores the list of already used paths
+  # @return [String] the path as is, or with the suffix required to make it unique
+  def self.call(path, while_included_in)
+    return path unless while_included_in.include?(path)
+
+    # we add (1), (2), (n) at the end of a filename before the filename extension,
+    # but only if there is a duplicate
+    copy_pattern = /\((\d+)\)$/
+    parts = path.split('.')
+    ext = if parts.last =~ /gz|zip/ && parts.size > 2
+            parts.pop(2)
+          elsif parts.size > 1
+            parts.pop
+          end
+    fn_last_part = parts.pop
+
+    duplicate_counter = 1
+    loop do
+      fn_last_part = if fn_last_part =~ copy_pattern
+                       fn_last_part.sub(copy_pattern, "(#{duplicate_counter})")
+                     else
+                       "#{fn_last_part} (#{duplicate_counter})"
+                     end
+      new_path = (parts + [fn_last_part, ext]).compact.join('.')
+      return new_path unless while_included_in.include?(new_path)
+      duplicate_counter += 1
+    end
+  end
+end

--- a/lib/zip_tricks/version.rb
+++ b/lib/zip_tricks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipTricks
-  VERSION = '4.7.4'
+  VERSION = '4.8.0'
 end

--- a/spec/zip_tricks/path_set_spec.rb
+++ b/spec/zip_tricks/path_set_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe ZipTricks::PathSet do
+  it 'allows adding multiple files' do
+    expect {
+      subject.add_file_path('foo.txt')
+      subject.add_file_path('bar.txt')
+      subject.add_file_path('baz.txt')
+      subject.add_directory_path('subdir')
+    }.not_to raise_error
+  end
+
+  it 'does not raise when a directory gets added twice' do
+    expect {
+      subject.add_directory_path('subdir')
+      subject.add_directory_path('subdir')
+    }.not_to raise_error
+  end
+
+  it 'raises when a file would clobber a directory' do
+    subject.add_directory_path('maybe-dir-maybe-file')
+    expect {
+      subject.add_file_path('maybe-dir-maybe-file')
+    }.to raise_error(described_class::FileClobbersDirectory)
+  end
+
+  it 'raises when a directory would clobber a file' do
+    subject.add_file_path('maybe-dir-maybe-file')
+    expect {
+      subject.add_directory_path('maybe-dir-maybe-file')
+    }.to raise_error(described_class::DirectoryClobbersFile)
+  end
+
+  it 'raises when a file would clobber a directory to create its implicit subtree' do
+    subject.add_file_path('a/b/c/d/e/f')
+    expect {
+      subject.add_file_path('a/b/c/d/e/f/g')
+    }.to raise_error(described_class::DirectoryClobbersFile)
+  end
+
+  it 'raises when a directory would clobber a file to create its implicit subtree' do
+    subject.add_file_path('a/b/c/d/e/f')
+    expect {
+      subject.add_directory_path('a/b/c/d/e/f/g')
+    }.to raise_error(described_class::DirectoryClobbersFile)
+  end
+
+  describe '#include?' do
+    it 'answers both for specifically added items and for their path components' do
+      subject.add_file_path('dir1/dir2/file.doc')
+      subject.add_directory_path('another-dir/')
+
+      expect(subject).to include('dir1')
+      expect(subject).to include('dir1/dir2')
+      expect(subject).to include('dir1/dir2/file.doc')
+      expect(subject).to include('another-dir')
+
+      expect(subject).not_to include('dir2') # This is only included with its parent
+      expect(subject).not_to include('not-there') # Just not in this set
+    end
+  end
+
+  describe '#clear' do
+    it 'deletes elements' do
+      subject.add_file_path('f')
+      subject.add_directory_path('d')
+
+      expect(subject).to include('d')
+      expect(subject).to include('f')
+
+      subject.clear
+
+      expect(subject).not_to include('d')
+      expect(subject).not_to include('f')
+    end
+  end
+end

--- a/spec/zip_tricks/size_estimator_spec.rb
+++ b/spec/zip_tricks/size_estimator_spec.rb
@@ -36,6 +36,21 @@ describe ZipTricks::SizeEstimator do
     expect(predicted_size).to eq(2_690_321)
   end
 
+  it 'passes the keyword arguments to Streamer#new' do
+    expect {
+      described_class.estimate(auto_rename_duplicate_filenames: false) do |estimator|
+        estimator.add_stored_entry(filename: 'first-file.bin', size: 123)
+        estimator.add_stored_entry(filename: 'first-file.bin', size: 123)
+      end
+    }.to raise_error(ZipTricks::PathSet::Conflict)
+
+    size = described_class.estimate(auto_rename_duplicate_filenames: true) do |estimator|
+      estimator.add_stored_entry(filename: 'first-file.bin', size: 123)
+      estimator.add_stored_entry(filename: 'first-file.bin', size: 123)
+    end
+    expect(size).to eq(549)
+  end
+
   it 'still supports #add_compressed_entry (to be removed in v.5)' do
     predicted_size = described_class.estimate do |zip|
       zip.add_compressed_entry(filename: 'foo.bar', compressed_size: 123, uncompressed_size: 456)

--- a/spec/zip_tricks/uniquify_filename_spec.rb
+++ b/spec/zip_tricks/uniquify_filename_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe ZipTricks::UniquifyFilename do
+  it 'returns the filename as is if it is not present in the check set' do
+    check_set = Set.new
+    expect(described_class.call("file.txt", check_set)).to eq("file.txt")
+    expect(check_set).to be_empty, "Should not have added anything to the check set"
+  end
+
+  it 'deduplicates the filename if it is already contained in the set of unique names' do
+    check_set = Set.new(["foo.txt"])
+    expect(described_class.call("foo.txt", check_set)).to eq("foo (1).txt")
+  end
+
+  it 'deduplicates the filename and increments the counter as long as necessary to arrive at a unique one' do
+    check_set = Set.new(["foo.txt", "foo (1).txt", "foo (2).txt"])
+    expect(described_class.call("foo.txt", check_set)).to eq("foo (3).txt")
+  end
+
+  it 'when the filename extension is .gd and there is an extension in front of it, inserts the counter before that extension' do
+    check_set = Set.new(["foo.data.gz"])
+    expect(described_class.call("foo.data.gz", check_set)).to eq("foo (1).data.gz")
+  end
+end


### PR DESCRIPTION
We have been having a number of situations where
an implicitly created directory in longer paths
would "occupy" a path component that would then
be taken up by a file. With some applications it
is simply not possible to extract such an archive,
and also the filesystem structure it would create
is not really defined.

To avoid this we should verify the paths added
during the archive creation - and we need to do
it when every entry gets added to the internal
entry list, at the earliest possible opportunity.

It also shows that our uniquify calls to avoid
duplicate filenames lead to ambiguous situations,
so we make this optional with a default of "true".

We keep the option enabled by default to make sure
we do not break zipline which relies on us doing
the uniqueness fixing for them (we asked for it).

So even though we can fix it in our own output,
it is not reasonable to expect all of our users to
do the same, _and_ there are guarantees of semver.