### PR TITLE
Adopt Hippocratic license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 5.0.0
 
 * Adopt [Hippocratic license v. 1.2](https://firstdonoharm.dev/version/1/2/license.html)
+  Note that this might make the license conditions unacceptable for your project. If that is the case,
+  you can use the 4.x branch of the library which stays under the original, exact MIT license.
 
 ## 4.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.0
+
+* Adopt [Hippocratic license v. 1.2](https://firstdonoharm.dev/version/1/2/license.html)
+
 ## 4.8.0
 
 * Make sure that when directories clobber files and vice versa we raise a clear error. Add `PathSet` which keeps track of entries

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,20 +1,17 @@
-Copyright (c) 2019 WeTransfer
+Copyright 2019 WeTransfer
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+* No Harm: The software may not be used by anyone for systems or activities that actively and knowingly endanger, harm, or otherwise threaten the physical, mental, economic, or general well-being of other individuals or groups, in violation of the United Nations Universal Declaration of Human Rights (https://www.un.org/en/universal-declaration-human-rights/).
+
+* Services: If the Software is used to provide a service to others, the licensee shall, as a condition of use, require those others not to use the service in any way that violates the No Harm clause above.
+
+* Enforceability: If any portion or provision of this License shall to any extent be declared illegal or unenforceable by a court of competent jurisdiction, then the remainder of this License, or the application of such portion or provision in circumstances other than those as to which it is so declared illegal or unenforceable, shall not be affected thereby, and each portion and provision of this Agreement shall be valid and enforceable to the fullest extent permitted by law.
+
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+This Hippocratic License is an Ethical Source license (https://ethicalsource.dev) derived from the MIT License, amended to limit the impact of the unethical use of open source software.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,17 +1,44 @@
-Copyright 2019 WeTransfer
+Copyright (c) 2019 WeTransfer
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
+* The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
 
-* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+* No Harm: The software may not be used by anyone for systems or
+  activities that actively and knowingly endanger, harm, or otherwise
+  threaten the physical, mental, economic, or general well-being of
+  other individuals or groups, in violation of the United Nations
+  Universal Declaration of Human Rights
+  (https://www.un.org/en/universal-declaration-human-rights/).
 
-* No Harm: The software may not be used by anyone for systems or activities that actively and knowingly endanger, harm, or otherwise threaten the physical, mental, economic, or general well-being of other individuals or groups, in violation of the United Nations Universal Declaration of Human Rights (https://www.un.org/en/universal-declaration-human-rights/).
+* Services: If the Software is used to provide a service to others, the
+  licensee shall, as a condition of use, require those others not to use
+  the service in any way that violates the No Harm clause above.
 
-* Services: If the Software is used to provide a service to others, the licensee shall, as a condition of use, require those others not to use the service in any way that violates the No Harm clause above.
+* Enforceability: If any portion or provision of this License shall to
+  any extent be declared illegal or unenforceable by a court of
+  competent jurisdiction, then the remainder of this License, or the
+  application of such portion or provision in circumstances other than
+  those as to which it is so declared illegal or unenforceable, shall
+  not be affected thereby, and each portion and provision of this
+  Agreement shall be valid and enforceable to the fullest extent
+  permitted by law.
 
-* Enforceability: If any portion or provision of this License shall to any extent be declared illegal or unenforceable by a court of competent jurisdiction, then the remainder of this License, or the application of such portion or provision in circumstances other than those as to which it is so declared illegal or unenforceable, shall not be affected thereby, and each portion and provision of this Agreement shall be valid and enforceable to the fullest extent permitted by law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-This Hippocratic License is an Ethical Source license (https://ethicalsource.dev) derived from the MIT License, amended to limit the impact of the unethical use of open source software.
+This Hippocratic License is an Ethical Source license
+(https://ethicalsource.dev) derived from the MIT License, amended to
+limit the impact of the unethical use of open source software.

--- a/README.md
+++ b/README.md
@@ -178,4 +178,5 @@ that have not been formally verified (ours hasn't been).
 
 ## Copyright
 
-Copyright (c) 2019 WeTransfer. See LICENSE.txt for further details.
+Copyright (c) 2019 WeTransfer. `zip_tricks` is distributed under the conditions of the [Hippocratic License](https://firstdonoharm.dev/version/1/2/license.html)
+ - See LICENSE.txt for further details.

--- a/lib/zip_tricks/version.rb
+++ b/lib/zip_tricks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipTricks
-  VERSION = '4.8.0'
+  VERSION = '5.0.0'
 end

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors        = ['Julik Tarkhanov']
   spec.email          = ['me@julik.nl']
 
+  s.licenses          = ['MIT (Hippocratic)']
   spec.summary        = 'Stream out ZIP files from Ruby'
   spec.description    = 'Stream out ZIP files from Ruby'
   spec.homepage       = 'http://github.com/wetransfer/zip_tricks'

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -5,10 +5,10 @@ require 'zip_tricks/version'
 Gem::Specification.new do |spec|
   spec.name           = 'zip_tricks'
   spec.version        = ZipTricks::VERSION
-  spec.authors        = ['Julik Tarkhanov']
+  spec.authors        = ['Julik Tarkhanov', 'Noah Berman', 'Dmitry Tymchuk', 'David Bosveld']
   spec.email          = ['me@julik.nl']
 
-  spec.licenses          = ['MIT (Hippocratic)']
+  spec.licenses       = ['MIT (Hippocratic)']
   spec.summary        = 'Stream out ZIP files from Ruby'
   spec.description    = 'Stream out ZIP files from Ruby'
   spec.homepage       = 'http://github.com/wetransfer/zip_tricks'

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors        = ['Julik Tarkhanov']
   spec.email          = ['me@julik.nl']
 
-  s.licenses          = ['MIT (Hippocratic)']
+  spec.licenses          = ['MIT (Hippocratic)']
   spec.summary        = 'Stream out ZIP files from Ruby'
   spec.description    = 'Stream out ZIP files from Ruby'
   spec.homepage       = 'http://github.com/wetransfer/zip_tricks'


### PR DESCRIPTION
As @bermannoah noticed in the format_parser pull request it is a good idea for us to adopt a more restrictive license.

This makes the license zip_tricks is under more restrictive than it used to be. To limit impact on downstream dependencies such as xlsxtream I opted to increment the major version of the gem so that its update will be more visible and the dependents can elect to stay on 4.x version tree.

The 4.x will stay under the basic MIT license so that we do not suddenly de-license current users of the software.