### PR TITLE
Disable automatic deduplication by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0
 
+* Disable automatic filename deduplication by default, because it does not play nice with file/directory
+  clobbering. The option can still be enabled by passing `auto_rename_duplicate_filenames: true` to the Streamer
+  and all modules that use it
 * Adopt [Hippocratic license v. 1.2](https://firstdonoharm.dev/version/1/2/license.html)
   Note that this might make the license conditions unacceptable for your project. If that is the case,
   you can use the 4.x branch of the library which stays under the original, exact MIT license.

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -141,11 +141,9 @@ class ZipTricks::Streamer
   # @param writer[ZipTricks::ZipWriter] the object to be used as the writer.
   #    Defaults to an instance of ZipTricks::ZipWriter, normally you won't need to override it
   # @param auto_rename_duplicate_filenames[Boolean] whether duplicate filenames, when encountered,
-  #    should be suffixed with (1), (2) etc. Default value is `true` since it
-  #    used to be the default behavior.
-  #
-  # **DEPRECATION NOTICE** In ZipTricks version 5 `auto_rename_duplicate_filenames` will default to `false`
-  def initialize(stream, writer: create_writer, auto_rename_duplicate_filenames: true)
+  #    should be suffixed with (1), (2) etc. Default value is `false` - if
+  #    dupliate names are used an exception will be raised
+  def initialize(stream, writer: create_writer, auto_rename_duplicate_filenames: false)
     raise InvalidOutput, 'The stream must respond to #<<' unless stream.respond_to?(:<<)
 
     @dedupe_filenames = auto_rename_duplicate_filenames

--- a/spec/zip_tricks/size_estimator_spec.rb
+++ b/spec/zip_tricks/size_estimator_spec.rb
@@ -7,12 +7,13 @@ describe ZipTricks::SizeEstimator do
     raw_file_two = Random.new.bytes(1_024 * 128)
     raw_file_three = Random.new.bytes(1_258_695)
 
-    predicted_size = described_class.estimate do |estimator|
+    predicted_size = described_class.estimate(auto_rename_duplicate_filenames: true) do |estimator|
       r = estimator.add_stored_entry(filename: 'first-file.bin', size: raw_file_one.size)
       expect(r).to eq(estimator), 'add_stored_entry should return self'
 
       estimator.add_stored_entry(filename: 'second-file.bin', size: raw_file_two.size)
 
+      # This filename will be deduplicated and will therefore grow in size
       r = estimator.add_deflated_entry(filename: 'second-file.bin',
                                        compressed_size: raw_file_three.size,
                                        uncompressed_size: raw_file_two.size)


### PR DESCRIPTION
As noted in the deprecation comment. Automatically
suffixing filenames with " (1)", " (2)" and so on is
a little difficult when dealing with directory nesting,
and represents a bit of "magic" that should, ideally, be
removed. However, some libraries might still be reliant
on it so we use the major version change to alter the default
value now.