### PR TITLE
Update syntax and wetransfer_style for Ruby 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ Layout/FirstMethodArgumentLineBreak:
   Enabled: false
 Layout/FirstMethodParameterLineBreak:
   Enabled: false
+Layout/HeredocIndentation:
+  Enabled: false # Newer rubocop enforces heredocs that are only available in 2.3+
 Style/GlobalVars:
   Exclude:
       - qa/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_gem:
   wetransfer_style: ruby/default.yml
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
 Layout/FirstMethodArgumentLineBreak:
   Enabled: false
 Layout/FirstMethodParameterLineBreak:

--- a/lib/zip_tricks/size_estimator.rb
+++ b/lib/zip_tricks/size_estimator.rb
@@ -43,9 +43,7 @@ class ZipTricks::SizeEstimator
                                size: size,
                                use_data_descriptor: use_data_descriptor)
     @streamer.simulate_write(size)
-    if use_data_descriptor
-      @streamer.update_last_entry_and_write_data_descriptor(crc32: 0, compressed_size: size, uncompressed_size: size)
-    end
+    @streamer.update_last_entry_and_write_data_descriptor(crc32: 0, compressed_size: size, uncompressed_size: size) if use_data_descriptor
     self
   end
 

--- a/lib/zip_tricks/stream_crc32.rb
+++ b/lib/zip_tricks/stream_crc32.rb
@@ -5,7 +5,7 @@ class ZipTricks::StreamCRC32
   STRINGS_HAVE_CAPACITY_SUPPORT = begin
     String.new('', capacity: 1)
     true
-  rescue ArgumentError
+                                  rescue ArgumentError
     false
   end
   CRC_BUF_SIZE = 1024 * 512

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -433,13 +433,13 @@ class ZipTricks::Streamer
   private
 
   def add_file_and_write_local_header(
-      filename:,
-      modification_time:,
-      crc32:,
-      storage_mode:,
-      compressed_size:,
-      uncompressed_size:,
-      use_data_descriptor:)
+    filename:,
+    modification_time:,
+    crc32:,
+    storage_mode:,
+    compressed_size:,
+    uncompressed_size:,
+    use_data_descriptor:)
 
     # Clean backslashes
     filename = remove_backslash(filename)

--- a/lib/zip_tricks/zip_writer.rb
+++ b/lib/zip_tricks/zip_writer.rb
@@ -115,9 +115,7 @@ class ZipTricks::ZipWriter
     # https://social.technet.microsoft.com/Forums/windows/en-US/6a60399f-2879-4859-b7ab-6ddd08a70948
     # TL;DR of it is: Windows 7 Explorer _will_ open Zip64 entries. However, it desires to have the
     # Zip64 extra field as _the first_ extra field.
-    if requires_zip64
-      extra_fields << zip_64_extra_for_local_file_header(compressed_size: compressed_size, uncompressed_size: uncompressed_size)
-    end
+    extra_fields << zip_64_extra_for_local_file_header(compressed_size: compressed_size, uncompressed_size: uncompressed_size) if requires_zip64
     extra_fields << timestamp_extra(mtime)
 
     io << [extra_fields.size].pack(C_UINT2)                # extra field length              2 bytes

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -19,13 +19,13 @@ describe ZipTricks::Streamer do
   end
 
   class FakeZipWriter
-    def write_local_file_header(*);               end
+    def write_local_file_header(*, **);               end
 
-    def write_data_descriptor(*);                 end
+    def write_data_descriptor(*, **);                 end
 
-    def write_central_directory_file_header(*);   end
+    def write_central_directory_file_header(*, **);   end
 
-    def write_end_of_central_directory(*);        end
+    def write_end_of_central_directory(*, **);        end
   end
 
   it 'has linear performance depending on the file count' do

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -43,5 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'allocation_stats', '~> 0.1.5'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'wetransfer_style', '0.6.0'
+  spec.add_development_dependency 'wetransfer_style', '0.7.0'
 end


### PR DESCRIPTION
The code also works "as-is" now on 2.7 with few warnings, but it is nicer to be up-to-date. We do have to wait for rspec-mocks to be updated though.