### PR TITLE
Add rubyzip changes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Slightly rework `RemoteIO` and `RemoteUncap` and make sure they work correctly by spinning up a test webserver
   to verify their operation. The changes to the documented API are fairly small so this is still marked as a minor
   release.
+* Lock rubyzip to version 1.x.
 
 ## 5.0.0
 
@@ -25,16 +26,16 @@
 
 ## 4.7.4
 
-* Use a single fixed capacity string in StreamCRC32.from_io to avoid unnecessary allocations
+* Use a single fixed capacity string in `StreamCRC32.from_io` to avoid unnecessary allocations
 * Fix a few tests that were calling out to external binaries
 
 ## 4.7.3
 
-* Fix RemoteUncap#request_object_size to function correctly
+* Fix `RemoteUncap#request_object_size` to function correctly
 
 ## 4.7.2
 
-* Relax bundler dependency so that both 1.x and 2.x are supported cleanly
+* Relax bundler dependency so that both rubyzip 1.x and 2.x are supported cleanly
 
 ## 4.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 * Slightly rework `RemoteIO` and `RemoteUncap` and make sure they work correctly by spinning up a test webserver
   to verify their operation. The changes to the documented API are fairly small so this is still marked as a minor
   release.
-* Lock rubyzip to version 1.x.
 
 ## 5.0.0
 
@@ -35,7 +34,7 @@
 
 ## 4.7.2
 
-* Relax bundler dependency so that both rubyzip 1.x and 2.x are supported cleanly
+* Relax bundler dependency so that both bundler 1.x and 2.x are supported cleanly
 
 ## 4.7.1
 


### PR DESCRIPTION
This came as a surprise to us because it wasn't mentioned in the commit message, as it seems the commits from [the PR](https://github.com/WeTransfer/zip_tricks/pull/64) were squashed.

This adds the information to the change log :)