### PR TITLE
Fix extended timestamp extra field output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.1.1
+
+* Fix extended timestamp extra field output. The first bit of the flag would be set instead of the last bit of
+  the flag, which made it impossible for Rubyzip to read the timestamp of the entry - and it would also make
+  the extra field useless for most reading applications.
+
 ## 5.1.0
 
 * Slightly rework `RemoteIO` and `RemoteUncap` and make sure they work correctly by spinning up a test webserver

--- a/lib/zip_tricks/version.rb
+++ b/lib/zip_tricks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipTricks
-  VERSION = '5.1.0'
+  VERSION = '5.1.1'
 end

--- a/spec/zip_tricks/zip_writer_spec.rb
+++ b/spec/zip_tricks/zip_writer_spec.rb
@@ -79,7 +79,7 @@ describe ZipTricks::ZipWriter do
 
       expect(br.read_2b).to eq(0x5455)       # Extended timestamp extra tag
       expect(br.read_2b).to eq(5)            # Size of the timestamp extra
-      expect(br.read_1b).to eq(128)          # The timestamp flag
+      expect(br.read_1b).to eq(1)            # The timestamp flag, with only the lowest bit set
 
       ext_mtime = br.read_4b_signed
       expect(ext_mtime).to eq(1_468_763_280) # The mtime encoded as a 4byte uint

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rubyzip', '~> 2.1'
+  spec.add_development_dependency 'rubyzip', '~> 1'
   spec.add_development_dependency 'terminal-table'
   spec.add_development_dependency 'range_utils'
 

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rubyzip', '~> 1', '>= 1.2.2'
+  spec.add_development_dependency 'rubyzip', '~> 2.1'
   spec.add_development_dependency 'terminal-table'
   spec.add_development_dependency 'range_utils'
 


### PR DESCRIPTION
Upon closer inspection of why Rubyzip 2.1 cannot work with our output it turns out that we write the timestamp extra fields incorrectly. To indicate that only mtime is present, the last bit of the flag byte needs to be set. We were erroneously setting the highest bit instead.

Since Rubyzip 2 attempts to read the extra timestamp field, and does it - it doesn't find the flag bit which instructs it to read the mtime from the extra field. Rubyzip _does not_ parse the "standard" time field if the timestamp extra field is present at all - so both the standard time for the entry and the time from the extra field end up being `nil`.

Closes #65 