### PR TITLE
Remove add_compressed_entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2
+
+* Remove `Streamer#add_compressed_entry` and `SizeEstimator#add_compressed_entry`
+
 ## 5.1.1
 
 * Fix extended timestamp extra field output. The first bit of the flag would be set instead of the last bit of

--- a/lib/zip_tricks/size_estimator.rb
+++ b/lib/zip_tricks/size_estimator.rb
@@ -73,9 +73,6 @@ class ZipTricks::SizeEstimator
     self
   end
 
-  # Will be phased out in ZipTricks 5.x
-  alias_method :add_compressed_entry, :add_deflated_entry
-
   # Add an empty directory to the archive.
   #
   # @param dirname [String] the name of the directory

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -213,9 +213,6 @@ class ZipTricks::Streamer
     @out.tell
   end
 
-  # Will be phased out in ZipTricks 5.x
-  alias_method :add_compressed_entry, :add_deflated_entry
-
   # Writes out the local header for an entry (file in the ZIP) that is using
   # the stored storage model (is stored as-is).
   # Once this method is called, the `<<` method has to be called one or more

--- a/lib/zip_tricks/version.rb
+++ b/lib/zip_tricks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipTricks
-  VERSION = '5.1.1'
+  VERSION = '5.2.0'
 end

--- a/spec/zip_tricks/size_estimator_spec.rb
+++ b/spec/zip_tricks/size_estimator_spec.rb
@@ -51,5 +51,4 @@ describe ZipTricks::SizeEstimator do
     end
     expect(size).to eq(549)
   end
-
 end

--- a/spec/zip_tricks/size_estimator_spec.rb
+++ b/spec/zip_tricks/size_estimator_spec.rb
@@ -52,10 +52,4 @@ describe ZipTricks::SizeEstimator do
     expect(size).to eq(549)
   end
 
-  it 'still supports #add_compressed_entry (to be removed in v.5)' do
-    predicted_size = described_class.estimate do |zip|
-      zip.add_compressed_entry(filename: 'foo.bar', compressed_size: 123, uncompressed_size: 456)
-    end
-    expect(predicted_size).to be > 0
-  end
 end

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -285,14 +285,6 @@ describe ZipTricks::Streamer do
     Dir.chdir(wd)
   end
 
-  it 'still supports #add_compressed_entry (to be removed in v.5)' do
-    out = StringIO.new
-    zip = described_class.new(out)
-    zip.add_compressed_entry(filename: 'foo.bar', compressed_size: 123, uncompressed_size: 456, crc32: 9)
-    zip.close
-    expect(out.size).to be > 0
-  end
-
   it 'sets the general-purpose flag for entries with UTF8 names' do
     zip_buf = Tempfile.new('zipp')
     zip_buf.binmode


### PR DESCRIPTION
It was slated for removal in 5.x anyway