### PR TITLE
Raise on Streamer offset mismatch

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,5 @@ Style/GlobalVars:
       - qa/*.rb
       - spec/spec_helper.rb
       - spec/support/zip_inspection.rb
+Layout/IndentHeredoc:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 5.3
+
+* Raise in `Streamer#close` when the IO offset of the Streamer does not match the size of the written entries. This is a situation which
+  can occur if one adds the local headers, writes the bodies of the files to the socket/output directly, and forgets to adjust the internal
+  Streamer offset. The unadjusted offset would then produce incorrect values in both the local headers which come after the missing
+  offset adjustment _and_ in the central directory headers. Some ZIP unarchivers are able to recover from this (ones that read
+  files "straight-ahead" but others aren't - if the ZIP unarchiver uses central directory entries it would be using incorrect offsets.
+  Instead of producing an invalid ZIP, raise an exception which explains what happened and how it can be resolved.
+
 ## 5.2
 
 * Remove `Streamer#add_compressed_entry` and `SizeEstimator#add_compressed_entry`

--- a/lib/zip_tricks/file_reader.rb
+++ b/lib/zip_tricks/file_reader.rb
@@ -82,7 +82,9 @@ class ZipTricks::FileReader
 
   private_constant :StoredReader, :InflatingReader
 
-  # Represents a file within the ZIP archive being read
+  # Represents a file within the ZIP archive being read. This is different from
+  # the Entry object used in Streamer for ZIP writing, since during writing more
+  # data can be kept in memory for immediate use.
   class ZipEntry
     # @return [Fixnum] bit-packed version signature of the program that made the archive
     attr_accessor :made_by

--- a/lib/zip_tricks/streamer/entry.rb
+++ b/lib/zip_tricks/streamer/entry.rb
@@ -4,7 +4,7 @@
 # Normally you will not have to use this class directly
 class ZipTricks::Streamer::Entry < Struct.new(:filename, :crc32, :compressed_size,
                                               :uncompressed_size, :storage_mode, :mtime,
-                                              :use_data_descriptor)
+                                              :use_data_descriptor, :local_header_offset, :bytes_used_for_local_header, :bytes_used_for_data_descriptor)
   def initialize(*)
     super
     filename.force_encoding(Encoding::UTF_8)
@@ -13,6 +13,10 @@ class ZipTricks::Streamer::Entry < Struct.new(:filename, :crc32, :compressed_siz
                            rescue
                              false
                            end)
+  end
+
+  def total_bytes_used
+    bytes_used_for_local_header + compressed_size + bytes_used_for_data_descriptor
   end
 
   # Set the general purpose flags for the entry. We care about is the EFS

--- a/lib/zip_tricks/version.rb
+++ b/lib/zip_tricks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipTricks
-  VERSION = '5.2.0'
+  VERSION = '5.3.0'
 end

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -561,6 +561,14 @@ describe ZipTricks::Streamer do
     }.not_to raise_error(ZipTricks::PathSet::Conflict)
   end
 
+  it 'raises when the IO offset is out of sync with the sizes of the entries known to the Streamer' do
+    expect {
+      described_class.open(StringIO.new, auto_rename_duplicate_filenames: false) do |zip_streamer|
+        zip_streamer.add_stored_entry(filename: 'foo/bar/baz', size: 1_024, crc32: 0xCC)
+      end
+    }.to raise_error(ZipTricks::Streamer::OffsetOutOfSync, /Entries add up to \d+ bytes and the IO is at 50 bytes/)
+  end
+
   it 'writes the specified modification time' do
     fake_writer = double('Writer').as_null_object
 


### PR DESCRIPTION
To prevent a situation where a user might forget to use `sumulate_write` -
we want to make this failure mode explicit and early. Otherwise an invalid
ZIP might get produced.

This verification is performed when the central directory gets written -
we could fail earlier with it, but then we would need to walk all written
entries in order, after each added entry. This would make the algorithm
accidentally quadratic. If we want better performance we need to add an
additional offset tracking, and update it on every entry. This will allow
us to fail earlier, but is a bit of a drag to implement correctly.

To me it seems that failing at central directory output is a sensible compromise.