### PR TITLE
Extra timestamp broken

### DIFF
--- a/lib/zip_tricks/zip_writer.rb
+++ b/lib/zip_tricks/zip_writer.rb
@@ -57,7 +57,7 @@ class ZipTricks::ZipWriter
   C_UINT2 = 'v'    # Encode a 2-byte unsigned little-endian uint
   C_UINT8 = 'Q<'  # Encode an 8-byte unsigned little-endian uint
   C_CHAR = 'C' # For bit-encoded strings
-  C_INT4 = 'N' # Encode a 4-byte signed little-endian int
+  C_INT4 = 'l<' # Encode a 4-byte signed little-endian int
 
   private_constant :FOUR_BYTE_MAX_UINT,
                    :TWO_BYTE_MAX_UINT,
@@ -385,7 +385,7 @@ class ZipTricks::ZipWriter
       0x5455, C_UINT2,  # tag for this extra block type ("UT")
       (1 + 4), C_UINT2, # the size of this block (1 byte used for the Flag + 3 longs used for the timestamp)
       flags, C_CHAR,   # encode a single byte
-      mtime.utc.to_i, C_INT4, # Use a signed long, not the unsigned one used by the rest of the ZIP spec.
+      mtime.utc.to_i, C_INT4, # Use a signed int, not the unsigned one used by the rest of the ZIP spec.
     ]
     # The atime and ctime can be omitted if not present
     pack_array(data_and_packspecs)

--- a/spec/zip_tricks/zip_writer_spec.rb
+++ b/spec/zip_tricks/zip_writer_spec.rb
@@ -23,7 +23,7 @@ describe ZipTricks::ZipWriter do
     end
 
     def read_4b_signed
-      read_n(4).unpack('N').first
+      read_n(4).unpack('l<').first
     end
 
     def read_8b


### PR DESCRIPTION
# Extra timestamp broken

HI!
I found a problem about extra timestamps.

## Sample code

```
#!/usr/bin/env ruby
# Usage: ruby app.rb
require "bundler/inline"
gemfile(true) do
  source "https://rubygems.org"
  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
  gem "zip_tricks", "5.3.0"
end
require "zip_tricks"
File.open("test.zip", "wb") do |out|
  ZipTricks::Streamer.open(out) do |zip|
    zip.write_stored_file('app.rb') do |sink|
      File.open('app.rb', 'rb') { |source| IO.copy_stream(source, sink) }
    end
  end
end
system(%(zipinfo -v test.zip))
```

## Results on MacOSX

```
Archive:  test.zip
The zipfile comment is 29 bytes long and contains the following text:
======================== zipfile comment begins ==========================
Written using ZipTricks 5.3.0
========================= zipfile comment ends ===========================

End-of-central-directory record:
-------------------------------

  Zip archive file size:                       251 (00000000000000FBh)
  Actual end-cent-dir record offset:           200 (00000000000000C8h)
  Expected end-cent-dir record offset:         200 (00000000000000C8h)
  (based on the length of the central directory and its expected offset)

  This zipfile constitutes the sole disk of a single-part archive; its
  central directory contains 1 entry.
  The central directory is 61 (000000000000003Dh) bytes long,
  and its (expected) offset in bytes from the beginning of the zipfile
  is 139 (000000000000008Bh).


Central directory entry #1:
---------------------------

  app.rb

  offset of local header from start of archive:   0
                                                  (0000000000000000h) bytes
  file system or operating system of origin:      Unix
  version of encoding software:                   5.2
  minimum file system compatibility required:     MS-DOS, OS/2 or NT FAT
  minimum software version required to extract:   2.0
  compression method:                             none (stored)
  file security status:                           not encrypted
  extended local header:                          yes
  file last modified on (DOS date/time):          2020 Jun 11 14:35:30
  file last modified on (UT extra field modtime): 1996 Sep 20 09:16:30 local
  file last modified on (UT extra field modtime): 1996 Sep 20 00:16:30 UTC
  32-bit CRC value (hex):                         c931b512
  compressed size:                                78 bytes
  uncompressed size:                              78 bytes
  length of filename:                             6 characters
  length of extra field:                          9 bytes
  length of file comment:                         0 characters
  disk number on which file begins:               disk 1
  apparent file type:                             binary
  Unix file attributes (100644 octal):            -rw-r--r--
  MS-DOS file attributes (00 hex):                none

  The central-directory extra field contains:
  - A subfield with ID 0x5455 (universal time) and 5 data bytes.
    The local extra field has UTC/GMT modification time.

  There is no file comment.

```

File last modified field looks bad.

>   file last modified on (DOS date/time):          2020 Jun 11 14:35:30
>  file last modified on (UT extra field modtime): 1996 Sep 20 09:16:30 local
>  file last modified on (UT extra field modtime): 1996 Sep 20 00:16:30 UTC

## Solution

Use `l<` to pack timestamp extra.

```
Archive:  test.zip
The zipfile comment is 29 bytes long and contains the following text:
======================== zipfile comment begins ==========================
Written using ZipTricks 5.3.0
========================= zipfile comment ends ===========================

End-of-central-directory record:
-------------------------------

  Zip archive file size:                       251 (00000000000000FBh)
  Actual end-cent-dir record offset:           200 (00000000000000C8h)
  Expected end-cent-dir record offset:         200 (00000000000000C8h)
  (based on the length of the central directory and its expected offset)

  This zipfile constitutes the sole disk of a single-part archive; its
  central directory contains 1 entry.
  The central directory is 61 (000000000000003Dh) bytes long,
  and its (expected) offset in bytes from the beginning of the zipfile
  is 139 (000000000000008Bh).


Central directory entry #1:
---------------------------

  app.rb

  offset of local header from start of archive:   0
                                                  (0000000000000000h) bytes
  file system or operating system of origin:      Unix
  version of encoding software:                   5.2
  minimum file system compatibility required:     MS-DOS, OS/2 or NT FAT
  minimum software version required to extract:   2.0
  compression method:                             none (stored)
  file security status:                           not encrypted
  extended local header:                          yes
  file last modified on (DOS date/time):          2020 Jun 11 14:40:26
  file last modified on (UT extra field modtime): 2020 Jun 11 23:40:27 local
  file last modified on (UT extra field modtime): 2020 Jun 11 14:40:27 UTC
  32-bit CRC value (hex):                         c931b512
  compressed size:                                78 bytes
  uncompressed size:                              78 bytes
  length of filename:                             6 characters
  length of extra field:                          9 bytes
  length of file comment:                         0 characters
  disk number on which file begins:               disk 1
  apparent file type:                             binary
  Unix file attributes (100644 octal):            -rw-r--r--
  MS-DOS file attributes (00 hex):                none

  The central-directory extra field contains:
  - A subfield with ID 0x5455 (universal time) and 5 data bytes.
    The local extra field has UTC/GMT modification time.

  There is no file comment.
```

## See also

[class Array - Documentation for Ruby 2.7.0](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-pack)