### PR TITLE
Get rid of Rails streaming in favor of iterables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ to [32 bit sizes.](https://github.com/jruby/jruby/issues/3817)
 
 ## Diving in: send some large CSV reports from Rails
 
-The easiest is to use the Rails' built-in streaming feature:
+The easiest is to include the `ZipTricks::RailsStreaming` module into your
+controller.
 
 ```ruby
 class ZipsController < ActionController::Base
-  include ActionController::Live # required for streaming
   include ZipTricks::RailsStreaming
 
   def download
@@ -48,6 +48,10 @@ class ZipsController < ActionController::Base
   end
 end
 ```
+
+If you want some more conveniences you can also use [zipline](https://github.com/fringd/zipline) which
+will automatically process and stream attachments (Carrierwave, Shrine, ActiveStorage) and remote objects
+via HTTP.
 
 ## Create a ZIP file without size estimation, compress on-the-fly during writes
 

--- a/lib/zip_tricks/rails_streaming.rb
+++ b/lib/zip_tricks/rails_streaming.rb
@@ -6,7 +6,10 @@ module ZipTricks::RailsStreaming
   # Opens a {ZipTricks::Streamer} and yields it to the caller. The output of the streamer
   # gets automatically forwarded to the Rails response stream. When the output completes,
   # the Rails response stream is going to be closed automatically.
+  # @param zip_streamer_options[Hash] options that will be passed to the Streamer.
+  #     See {ZipTricks::Streamer#initialize} for the full list of options.
   # @yield [Streamer] the streamer that can be written to
+  # @return [ZipTricks::OutputEnumerator] The output enumerator assigned to the response body
   def zip_tricks_stream(**zip_streamer_options, &zip_streaming_blk)
     # Set a reasonable content type
     response.headers['Content-Type'] = 'application/zip'

--- a/spec/zip_tricks/rails_streaming_spec.rb
+++ b/spec/zip_tricks/rails_streaming_spec.rb
@@ -5,8 +5,9 @@ describe ZipTricks::RailsStreaming do
     class FakeController
       include ZipTricks::RailsStreaming
       attr_reader :response
+      attr_accessor :response_body
       def initialize
-        @response = Struct.new(:headers, :stream).new({}, StringIO.new)
+        @response = Struct.new(:headers, :sending_file).new({})
       end
 
       def stream_zip
@@ -21,11 +22,22 @@ describe ZipTricks::RailsStreaming do
     ctr = FakeController.new
     ctr.stream_zip
     response = ctr.response
+    response_body = ctr.response_body
+
 
     expect(response.headers['Content-Type']).to eq('application/zip')
     expect(response.headers['X-Accel-Buffering']).to eq('no')
-    output_stream = response.stream
-    expect(output_stream).to be_closed
-    expect(output_stream.string).not_to be_empty
+    expect(response.sending_file).to be(true)
+
+    ref = StringIO.new('', 'wb')
+    ZipTricks::Streamer.open(ref) do |z|
+      z.write_deflated_file('hello.txt') do |f|
+        f << 'ßHello from Rails'
+      end
+    end
+
+    out = StringIO.new('', 'wb')
+    response_body.each.reduce(out, :<<)
+    expect(out.string).to eq(ref.string)
   end
 end

--- a/spec/zip_tricks/rails_streaming_spec.rb
+++ b/spec/zip_tricks/rails_streaming_spec.rb
@@ -19,7 +19,6 @@ describe ZipTricks::RailsStreaming do
       end
     end
 
-
     ctr = FakeController.new
     ctr.stream_zip
     response = ctr.response

--- a/spec/zip_tricks/rails_streaming_spec.rb
+++ b/spec/zip_tricks/rails_streaming_spec.rb
@@ -11,13 +11,14 @@ describe ZipTricks::RailsStreaming do
       end
 
       def stream_zip
-        zip_tricks_stream do |z|
+        zip_tricks_stream(auto_rename_duplicate_filenames: true) do |z|
           z.write_deflated_file('hello.txt') do |f|
             f << 'ßHello from Rails'
           end
         end
       end
     end
+
 
     ctr = FakeController.new
     ctr.stream_zip
@@ -34,6 +35,8 @@ describe ZipTricks::RailsStreaming do
         f << 'ßHello from Rails'
       end
     end
+
+    expect(ZipTricks::Streamer).to receive(:new).with(any_args, auto_rename_duplicate_filenames: true).and_call_original
 
     out = StringIO.new('', 'wb')
     response_body.each.reduce(out, :<<)

--- a/spec/zip_tricks/rails_streaming_spec.rb
+++ b/spec/zip_tricks/rails_streaming_spec.rb
@@ -24,7 +24,6 @@ describe ZipTricks::RailsStreaming do
     response = ctr.response
     response_body = ctr.response_body
 
-
     expect(response.headers['Content-Type']).to eq('application/zip')
     expect(response.headers['X-Accel-Buffering']).to eq('no')
     expect(response.sending_file).to be(true)

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -558,7 +558,9 @@ describe ZipTricks::Streamer do
       zip_streamer = described_class.new(StringIO.new, writer: fake_writer, auto_rename_duplicate_filenames: true)
       zip_streamer.add_stored_entry(filename: 'foo/bar/baz/bad', size: 1_024, crc32: 0xCC)
       zip_streamer.add_stored_entry(filename: 'foo/bar/baz', size: 1_024, crc32: 0xCC)
-    }.not_to raise_error(ZipTricks::PathSet::Conflict)
+      # The error raised would be ZipTricks::PathSet::Conflict but RSpec reasonably advises not using
+      # not_to raise_error(ZipTricks::PathSet::Conflict) due to the semantics of raise_error
+    }.not_to raise_error
   end
 
   it 'raises when the IO offset is out of sync with the sizes of the entries known to the Streamer' do


### PR DESCRIPTION
The Rails Live responses do not work correctly with
RSpec and other integration tests, and are fiddly.

It seems that the Zipline setup works better.