### PR TITLE
Fix hung specs running Archive Utility on macOS

### DIFF
--- a/spec/support/zip_inspection.rb
+++ b/spec/support/zip_inspection.rb
@@ -1,3 +1,5 @@
+require 'rbconfig'
+
 module ZipInspection
   def inspect_zip_with_external_tool(path_to_zip)
     zipinfo_path = 'zipinfo'
@@ -11,19 +13,37 @@ module ZipInspection
     $zip_inspection_buf.puts `#{escaped_cmd}`
   end
 
-  def open_with_external_app(app_path, path_to_zip, skip_if_missing)
+  def open_with_external_app(cmd, skip_if_missing)
+    app_path = cmd.first
     bin_exists = File.exist?(app_path)
     skip "This system does not have #{File.basename(app_path)}" if skip_if_missing && !bin_exists
     return unless bin_exists
-    `#{Shellwords.join([app_path, path_to_zip])}`
+    system(*cmd)
   end
 
-  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: false)
-    # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
-    # not perform any checks on the files since we do not really know where they are on disk.
-    # Visual inspection should show whether the unarchiving is handled correctly.
-    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/' \
-              'Contents/MacOS/Archive Utility'
-    open_with_external_app(au_path, path_to_zip, skip_if_missing)
+  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: false, expected_content: [])
+    unless RbConfig::CONFIG['host_os'].start_with? 'darwin'
+      skip "Archive Utility specs require macOS"
+      return
+    end
+    # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so
+    # we reset the preferences to unpack to current dir and don't show in Finder.
+    dearchive_reveal_after = `/usr/bin/defaults read com.apple.archiveutility dearchive-reveal-after`.to_i == 1
+    dearchive_into = `/usr/bin/defaults read com.apple.archiveutility dearchive-into`.chomp
+    # rubocop:disable Lint/UnneededSplatExpansion
+    begin
+      system *%w[/usr/bin/defaults write com.apple.archiveutility dearchive-reveal-after -bool false]
+      system *%w[/usr/bin/defaults delete com.apple.archiveutility dearchive-into] unless dearchive_into.empty?
+      cmd = %W[/usr/bin/open -WFjngb com.apple.archiveutility #{path_to_zip}]
+      result = open_with_external_app(cmd, skip_if_missing)
+    ensure
+      system *%W[/usr/bin/defaults write com.apple.archiveutility dearchive-reveal-after -bool #{dearchive_reveal_after}]
+      system *%W[/usr/bin/defaults write com.apple.archiveutility dearchive-into -string #{dearchive_into}] unless dearchive_into.empty?
+    end
+    # rubocop:enable Lint/UnneededSplatExpansion
+    expect(result).to be(true)
+    zip_path = File.join(File.dirname(path_to_zip), File.basename(path_to_zip, ".zip"))
+    expect(Dir.exist?(zip_path)).to be(true)
+    expect(Dir.entries(zip_path)[2..-1]).to match_array(expected_content)
   end
 end

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -224,7 +224,9 @@ describe ZipTricks::Streamer do
       File.rename(outbuf.path, 'osx-archive-test.zip')
 
       # Mark this test as skipped if the system does not have the binary
-      open_zip_with_archive_utility('osx-archive-test.zip', skip_if_missing: true)
+      open_zip_with_archive_utility('osx-archive-test.zip',
+                                    skip_if_missing: true,
+                                    expected_content: %w[war-and-peace.txt war-and-peace-raw.txt Beatles])
     end
     FileUtils.rm_rf('osx-archive-test')
     FileUtils.rm_rf('osx-archive-test.zip')


### PR DESCRIPTION
* Skip unless we're running macOS (Darwin)
* Use `open` to force separate copy and wait for exit
* Run using bundle id `com.apple.archiveutility` instead of path
* Temporarily change dearchive destination to cwd
* Temporarily disable showing folder in Finder after uncompress
* Check folder contents against provided list of entries