### PR TITLE
Fix Specs for JRuby / TruffleRuby

### DIFF
--- a/lib/zip_tricks/file_reader.rb
+++ b/lib/zip_tricks/file_reader.rb
@@ -281,7 +281,7 @@ class ZipTricks::FileReader
       seek(io, next_local_header_offset) # Seek to the next entry, and raise if seek is impossible
     end
     entries
-  rescue ReadError
+  rescue ReadError, RangeError # RangeError is raised if offset exceeds int32/int64 range
     log do
       'Got a read/seek error after reaching %<cur_offset>d, no more entries can be recovered' %
         {cur_offset: cur_offset}

--- a/spec/support/allocate_under_matcher.rb
+++ b/spec/support/allocate_under_matcher.rb
@@ -1,6 +1,10 @@
-require 'allocation_stats'
+require 'allocation_stats' if RUBY_ENGINE == 'ruby'
+
 RSpec::Matchers.define :allocate_under do |expected|
   match do |actual|
+    unless RUBY_ENGINE == 'ruby'
+      skip "allocation tracing not supported on #{RUBY_ENGINE}"
+    end
     @trace = actual.is_a?(Proc) ? AllocationStats.trace(&actual) : actual
     @trace.new_allocations.size < expected
   end

--- a/spec/zip_tricks/block_deflate_spec.rb
+++ b/spec/zip_tricks/block_deflate_spec.rb
@@ -8,7 +8,7 @@ describe ZipTricks::BlockDeflate do
   describe '.deflate_chunk' do
     it 'compresses a blob that can be inflated later, when the header, \
         footer and adler32 are added' do
-      blob = 'compressible' * 1024 * 4
+      blob = 'compressible' * (1024 * 4)
       compressed = described_class.deflate_chunk(blob)
       expect(compressed.bytesize).to be < blob.bytesize
       complete_deflated_segment = tag_deflated(compressed, blob)
@@ -16,20 +16,20 @@ describe ZipTricks::BlockDeflate do
     end
 
     it 'removes the header' do
-      blob = 'compressible' * 1024 * 4
+      blob = 'compressible' * (1024 * 4)
       compressed = described_class.deflate_chunk(blob)
       expect(compressed[0..1]).not_to eq([120, 156].pack('C*'))
     end
 
     it 'removes the adler32' do
-      blob = 'compressible' * 1024 * 4
+      blob = 'compressible' * (1024 * 4)
       compressed = described_class.deflate_chunk(blob)
       adler = [Zlib.adler32(blob)].pack('N')
       expect(compressed).not_to end_with(adler)
     end
 
     it 'removes the end marker' do
-      blob = 'compressible' * 1024 * 4
+      blob = 'compressible' * (1024 * 4)
       compressed = described_class.deflate_chunk(blob)
       expect(compressed[-7..-5]).not_to eq([3, 0].pack('C*'))
     end
@@ -37,14 +37,14 @@ describe ZipTricks::BlockDeflate do
     it 'honors the compression level' do
       deflater = Zlib::Deflate.new
       expect(Zlib::Deflate).to receive(:new).with(2) { deflater }
-      blob = 'compressible' * 1024 * 4
+      blob = 'compressible' * (1024 * 4)
       described_class.deflate_chunk(blob, level: 2)
     end
   end
 
   describe 'deflate_in_blocks_and_terminate' do
     it 'uses deflate_in_blocks' do
-      data = 'compressible' * 1024 * 1024 * 10
+      data = 'compressible' * (1024 * 1024 * 10)
       input = StringIO.new(data)
       output = StringIO.new
       block_size = 1024 * 64
@@ -56,7 +56,7 @@ describe ZipTricks::BlockDeflate do
     end
 
     it 'passes a custom compression level' do
-      data = 'compressible' * 1024 * 1024 * 10
+      data = 'compressible' * (1024 * 1024 * 10)
       input = StringIO.new(data)
       output = StringIO.new
       expect(described_class).to receive(:deflate_in_blocks).with(input,
@@ -67,7 +67,7 @@ describe ZipTricks::BlockDeflate do
     end
 
     it 'writes the end marker' do
-      data = 'compressible' * 1024 * 1024 * 10
+      data = 'compressible' * (1024 * 1024 * 10)
       input = StringIO.new(data)
       output = StringIO.new
       described_class.deflate_in_blocks_and_terminate(input, output)
@@ -85,7 +85,7 @@ describe ZipTricks::BlockDeflate do
 
   describe '.deflate_in_blocks' do
     it 'honors the block size' do
-      data = 'compressible' * 1024 * 1024 * 10
+      data = 'compressible' * (1024 * 1024 * 10)
       input = StringIO.new(data)
       output = StringIO.new
       block_size = 1024 * 64
@@ -99,7 +99,7 @@ describe ZipTricks::BlockDeflate do
     end
 
     it 'does not write the end marker' do
-      input_string = 'compressible' * 1024 * 1024 * 10
+      input_string = 'compressible' * (1024 * 1024 * 10)
       output_string = ''
 
       described_class.deflate_in_blocks(StringIO.new(input_string), StringIO.new(output_string))
@@ -108,7 +108,7 @@ describe ZipTricks::BlockDeflate do
     end
 
     it 'returns the number of bytes written' do
-      input_string = 'compressible' * 1024 * 1024 * 10
+      input_string = 'compressible' * (1024 * 1024 * 10)
       output_string = ''
 
       num_bytes = described_class.deflate_in_blocks(StringIO.new(input_string),

--- a/spec/zip_tricks/remote_uncap_spec.rb
+++ b/spec/zip_tricks/remote_uncap_spec.rb
@@ -13,7 +13,9 @@ describe ZipTricks::RemoteUncap do
     command = %W[bundle exec puma --bind tcp://#{@server_addr} #{rack_app}]
     server = IO.popen(command, 'r')
     @server_pid = server.pid
-    # Wait for server to boot
+    # ensure server was sarted
+    expect(@server_pid).not_to be_nil
+    # wait for server to boot
     true while server.gets !~ /Ctrl-C/
   end
 


### PR DESCRIPTION
* Fix missing `RangeError` rescue in `ZipTricks::FileError` (actual bugfix, also applies to MRI when offset >= 1**63)
* Skip allocation tracing checks on JRuby (not supported) and TruffleRuby (crashes)
* The block deflate spec did excessive string allocations due to operator precedence (fixed with brackets)
* The remote uncap spec used spawn, which doesn't work with JRuby – replaced with `IO.popen`

The following are improvements unrelated ro JRuby/TruffleRUby compatibility:
* RemoteUncap: Remove hardcoded timeout, wait for server to be ready by reading stdout (as used by puma's own integration tests)
* RemoteUncap: Remove hardcoded TCP port that could conflict, use a free one from ephemeral port range (we can't just grep for "Listening on http://127.0.0.1:5432", since until Puma 4.x the proper port wasn't shown and ruby 2.1 has to use 3.11.x)

