### PR TITLE
Replace macOS Archive Utility tests with libarchive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 rvm:
 - 2.1.0
 - 2.6.5
-- jruby-9.0
+- jruby-9.2
 sudo: false
+addons:
+  apt:
+    packages:
+      - libarchive-dev
 cache: bundler
 script:
   - bundle exec rake

--- a/spec/support/zip_inspection.rb
+++ b/spec/support/zip_inspection.rb
@@ -10,20 +10,4 @@ module ZipInspection
     escaped_cmd = Shellwords.join([zipinfo_path, '-tlhvz', path_to_zip])
     $zip_inspection_buf.puts `#{escaped_cmd}`
   end
-
-  def open_with_external_app(app_path, path_to_zip, skip_if_missing)
-    bin_exists = File.exist?(app_path)
-    skip "This system does not have #{File.basename(app_path)}" if skip_if_missing && !bin_exists
-    return unless bin_exists
-    `#{Shellwords.join([app_path, path_to_zip])}`
-  end
-
-  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: false)
-    # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
-    # not perform any checks on the files since we do not really know where they are on disk.
-    # Visual inspection should show whether the unarchiving is handled correctly.
-    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/' \
-              'Contents/MacOS/Archive Utility'
-    open_with_external_app(au_path, path_to_zip, skip_if_missing)
-  end
 end

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubyzip', '~> 1'
   spec.add_development_dependency 'terminal-table'
   spec.add_development_dependency 'range_utils'
+  spec.add_development_dependency 'ffi-libarchive'
 
   spec.add_development_dependency 'rack', '~> 1.6' # For Jeweler
   spec.add_development_dependency 'rake', '~> 12.2'


### PR DESCRIPTION
Since Archive Utility is a GUI app that is hard to automate and uses the systems' `libarchive2.dylib` under the hood, we just test against libarchive directly using the ffi-libarchive gem.

Since libarchive is available on Linux, we can run those specs in CI as well.