### PR TITLE
Uncap spec error handling fix

### DIFF
--- a/spec/zip_tricks/remote_uncap_spec.rb
+++ b/spec/zip_tricks/remote_uncap_spec.rb
@@ -16,12 +16,13 @@ describe ZipTricks::RemoteUncap do
     # ensure server was sarted
     expect(@server_pid).not_to be_nil
     # wait for server to boot
-    true while server.gets !~ /Ctrl-C/
+    expect { Timeout.timeout(10) { nil until server.gets =~ /Ctrl-C/ } }.not_to raise_error
   end
 
   after :all do
+    next if @server_pid.nil?
     begin
-      Process.kill("TERM", @server_pid)
+      Process.kill('TERM', @server_pid)
     rescue Errno::ESRCH
     end
     begin


### PR DESCRIPTION
Fixes two small edge cases in the uncap spec:

* If the server failed to start, `server.pid` is `nil`, so the after hook failed
* If the output from the pipe never contained the string "Ctrl-C", it would hang in a blocking read

While it would be cleaner to handle this with non-blocking reads, it requires much more code and the Ruby IO code is timeout-safe.