### PR TITLE
More JRuby CI Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,5 @@ rvm:
 - jruby-9.0
 sudo: false
 cache: bundler
-matrix:
-  allow_failures:
-    - rvm: jruby-9.0
 script:
   - bundle exec rake

--- a/spec/zip_tricks/block_deflate_spec.rb
+++ b/spec/zip_tricks/block_deflate_spec.rb
@@ -12,7 +12,7 @@ describe ZipTricks::BlockDeflate do
       compressed = described_class.deflate_chunk(blob)
       expect(compressed.bytesize).to be < blob.bytesize
       complete_deflated_segment = tag_deflated(compressed, blob)
-      expect(Zlib.inflate(complete_deflated_segment)).to eq(blob)
+      expect(Zlib::Inflate.inflate(complete_deflated_segment)).to eq(blob)
     end
 
     it 'removes the header' do


### PR DESCRIPTION
Since the last PR still allowed build failures for JRuby a small bug on 9.0 vs 9.2 used locally slipped through.

Fix that problem (`Zlib.inflate` missing on 9.0) and remove build failure exclude for jruby-9.0.