### PR TITLE
Remove macOS Archive Utility specs

### DIFF
--- a/spec/support/zip_inspection.rb
+++ b/spec/support/zip_inspection.rb
@@ -10,20 +10,4 @@ module ZipInspection
     escaped_cmd = Shellwords.join([zipinfo_path, '-tlhvz', path_to_zip])
     $zip_inspection_buf.puts `#{escaped_cmd}`
   end
-
-  def open_with_external_app(app_path, path_to_zip, skip_if_missing)
-    bin_exists = File.exist?(app_path)
-    skip "This system does not have #{File.basename(app_path)}" if skip_if_missing && !bin_exists
-    return unless bin_exists
-    `#{Shellwords.join([app_path, path_to_zip])}`
-  end
-
-  def open_zip_with_archive_utility(path_to_zip, skip_if_missing: false)
-    # ArchiveUtility sometimes puts the stuff it unarchives in ~/Downloads etc. so do
-    # not perform any checks on the files since we do not really know where they are on disk.
-    # Visual inspection should show whether the unarchiving is handled correctly.
-    au_path = '/System/Library/CoreServices/Applications/Archive Utility.app/' \
-              'Contents/MacOS/Archive Utility'
-    open_with_external_app(au_path, path_to_zip, skip_if_missing)
-  end
 end


### PR DESCRIPTION
These test are unreliable and hard to automate, since Archive Utility is a GUI app with no command line options.

See #86 for related discussion.