### PR TITLE
Don't change source encoding in WriteAndTell and BlockWrite

### DIFF
--- a/lib/zip_tricks/block_write.rb
+++ b/lib/zip_tricks/block_write.rb
@@ -23,20 +23,7 @@ class ZipTricks::BlockWrite
     # Zero-size output has a special meaning  when using chunked encoding
     return if buf.nil? || buf.bytesize.zero?
 
-    # Ensure we ALWAYS write in binary encoding.
-    encoded =
-      if buf.encoding != Encoding::BINARY
-        # If we got a frozen string we can't force_encoding on it
-        begin
-          buf.force_encoding(Encoding::BINARY)
-        rescue
-          buf.dup.force_encoding(Encoding::BINARY)
-        end
-      else
-        buf
-      end
-
-    @block.call(encoded)
+    @block.call(buf.b)
     self
   end
 end

--- a/lib/zip_tricks/write_and_tell.rb
+++ b/lib/zip_tricks/write_and_tell.rb
@@ -10,9 +10,8 @@ class ZipTricks::WriteAndTell
 
   def <<(bytes)
     return self if bytes.nil?
-    binary_bytes = binary(bytes)
-    @io << binary_bytes
-    @pos += binary_bytes.bytesize
+    @io << bytes.b
+    @pos += bytes.bytesize
     self
   end
 
@@ -22,14 +21,5 @@ class ZipTricks::WriteAndTell
 
   def tell
     @pos
-  end
-
-  private
-
-  def binary(str)
-    return str if str.encoding == Encoding::BINARY
-    str.force_encoding(Encoding::BINARY)
-  rescue RuntimeError # the string is frozen
-    str.dup.force_encoding(Encoding::BINARY)
   end
 end

--- a/spec/zip_tricks/block_write_spec.rb
+++ b/spec/zip_tricks/block_write_spec.rb
@@ -44,6 +44,15 @@ describe ZipTricks::BlockWrite do
     blobs.each { |s| expect(s.encoding).to eq(Encoding::BINARY) }
   end
 
+  it 'does not change the encoding of source strings' do
+    hello = 'hello'.encode(Encoding::UTF_8)
+    accum_string = ''.force_encoding(Encoding::BINARY)
+    adapter = described_class.new { |s| accum_string << s }
+    adapter << hello
+    expect(accum_string.encoding).to eq(Encoding::BINARY)
+    expect(hello.encoding).to eq(Encoding::UTF_8)
+  end
+
   it 'omits strings of zero length' do
     blobs = []
     adapter = described_class.new { |s| blobs << s }

--- a/spec/zip_tricks/file_reader_spec.rb
+++ b/spec/zip_tricks/file_reader_spec.rb
@@ -13,7 +13,7 @@ describe ZipTricks::FileReader do
   describe 'read_zip_straight_ahead' do
     it 'returns all the entries it can recover' do
       zipfile = StringIO.new
-      war_and_peace = File.read(__dir__ + '/war-and-peace.txt')
+      war_and_peace = File.binread(__dir__ + '/war-and-peace.txt')
       ZipTricks::Streamer.open(zipfile) do |zip|
         zip.add_stored_entry filename: 'text1.txt',
                              crc32: Zlib.crc32(war_and_peace),
@@ -209,7 +209,7 @@ describe ZipTricks::FileReader do
 
     it 'reads the file written stored with data descriptors' do
       zipfile = StringIO.new
-      tolstoy = File.read(__dir__ + '/war-and-peace.txt')
+      tolstoy = File.binread(__dir__ + '/war-and-peace.txt')
       ZipTricks::Streamer.open(zipfile) do |zip|
         zip.write_stored_file('war-and-peace.txt') do |sink|
           sink << tolstoy

--- a/spec/zip_tricks/write_and_tell_spec.rb
+++ b/spec/zip_tricks/write_and_tell_spec.rb
@@ -26,6 +26,16 @@ describe ZipTricks::WriteAndTell do
     expect(buf.bytesize).to eq(91) # It already contained some bytes
   end
 
+  it 'does not change the encoding of the source string' do
+    str = 'текста кусок'.force_encoding(Encoding::UTF_8)
+    buf = 'превед'.force_encoding(Encoding::BINARY)
+    writer = described_class.new(buf)
+    writer << str
+    expect(buf.bytesize).to eq(35)
+    expect(buf.encoding).to eq(Encoding::BINARY)
+    expect(str.encoding).to eq(Encoding::UTF_8)
+  end
+
   it 'is able to write into a null writer or a blackhole maintaining offsets' do
     writer = described_class.new(ZipTricks::NullWriter)
     writer << 'Hello'


### PR DESCRIPTION
Since `WriteAndTell#binary_bytes` and `BlockWrite#<<` were calling `String#force_encoding` on the written string, they were changing the encoding of the source strings.

This fixes the bugs and specs that accidentally depended on the mutation.