### PR TITLE
Optimize DeflatedWriter

### DIFF
--- a/lib/zip_tricks/streamer/deflated_writer.rb
+++ b/lib/zip_tricks/streamer/deflated_writer.rb
@@ -35,5 +35,7 @@ class ZipTricks::Streamer::DeflatedWriter
   def finish
     @compressed_io << @deflater.finish until @deflater.finished?
     {crc32: @crc.to_i, compressed_size: @deflater.total_out, uncompressed_size: @deflater.total_in}
+  ensure
+    @deflater.close
   end
 end

--- a/lib/zip_tricks/streamer/deflated_writer.rb
+++ b/lib/zip_tricks/streamer/deflated_writer.rb
@@ -22,7 +22,7 @@ class ZipTricks::Streamer::DeflatedWriter
   # @param data[String] data to be written
   # @return self
   def <<(data)
-    @compressed_io << @deflater.deflate(data)
+    @deflater.deflate(data) { |chunk| @compressed_io << chunk }
     @crc << data
     self
   end


### PR DESCRIPTION
* Drop interim flushing that will never trigger (Zlib will flush at roughly 4M with the default `Zlib::DEF_MEM_LEVEL` and 8M with `Zlib::MAX_MEM_LEVEL`, so flushing on 5M boundaries is useless)
* Use `Zlib::Streamer` methods to get compressed and uncompressed size
* Use block form of `deflate` to lower memory usage (especially when writing with `IO#each(nil, block_size) { |chunk| zip << chunk }`)
* Fix missing `Zlib::Deflate#close` call that caused about 250K mem leak per instance