### PR TITLE
Remove complexity_assert development dependency

### DIFF
--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 1.6' # For Jeweler
   spec.add_development_dependency 'rake', '~> 12.2'
   spec.add_development_dependency 'rspec', '~> 3'
-  spec.add_development_dependency 'complexity_assert'
   spec.add_development_dependency 'coderay'
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'allocation_stats', '~> 0.1.5'


### PR DESCRIPTION
This was used by the streamer spec to assert linear complexity, but causes a huge amount of array allocations with 300 MB memory usage and takes up about 40% of the entire test suite runtime for a single spec.

Instead replace it with a simple inline implementation that asserts linear complexity with 75% confidence interval.

While local tests show that the usual variance is within 5% or 95% confidence, the lower confidence is needed to account for fluctuation between test runs caused by GC or system load.

This could be counted by going for higher file counts, but starting from about 10K files that makes the spec unbearably slow.