### PR TITLE
adds ruby 3 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,13 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0'
           - '2.7'
           - '2.1'
           - 'jruby-9.2'
+        experimental: [false]
+        include:
+          - ruby: 3.0
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -89,4 +92,5 @@ jobs:
         if: steps.cache-gems.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
       - name: RSpec
+        continue-on-error: ${{ matrix.experimental }}
         run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.0'
           - '2.7'
           - '2.1'
           - 'jruby-9.2'
@@ -89,4 +90,3 @@ jobs:
         run: bundle install --jobs 4 --retry 3
       - name: RSpec
         run: bundle exec rspec
-

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ Gemfile.lock
 # jeweler generated
 pkg
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored
@@ -36,6 +36,7 @@ pkg
 
 tmp
 testing/*.zip
+.ruby-version
 
 # For TextMate
 #*.tmproj

--- a/spec/zip_tricks/block_deflate_spec.rb
+++ b/spec/zip_tricks/block_deflate_spec.rb
@@ -84,7 +84,7 @@ describe ZipTricks::BlockDeflate do
   end
 
   describe '.deflate_in_blocks' do
-    it 'honors the block size' do
+    it 'honors the block size', :aggregate_failures do
       data = 'compressible' * (1024 * 1024 * 10)
       input = StringIO.new(data)
       output = StringIO.new

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -273,7 +273,7 @@ describe ZipTricks::Streamer do
     end
   end
 
-  it 'writes the correct archive elements when using data descriptors' do
+  it 'writes the correct archive elements when using data descriptors', :aggregate_failures do
     out = StringIO.new
     fake_w = double('Writer')
     expect(fake_w).to receive(:write_local_file_header) { |**kwargs|
@@ -522,7 +522,7 @@ describe ZipTricks::Streamer do
     }.to raise_error(ZipTricks::Streamer::OffsetOutOfSync, /Entries add up to \d+ bytes and the IO is at 50 bytes/)
   end
 
-  it 'writes the specified modification time' do
+  it 'writes the specified modification time', :aggregate_failures do
     fake_writer = double('Writer').as_null_object
 
     expect(fake_writer).to receive(:write_local_file_header) { |**kwargs|


### PR DESCRIPTION
* adds Ruby 3.0 to the CI script
* git ignore `.ruby-version` (so I can run specs locally against multiple Ruby versions)

✅   Locally, for Ruby <= 2.7.2 specs are all passing
❌   For Ruby 3.0 some specs are failing. All errors seem to be related to the changed behavior for kwargs
  -> **update**: see comments below!

```
Finished in 19.31 seconds (files took 0.67243 seconds to load)
123 examples, 7 failures

Failed examples:

rspec ./spec/zip_tricks/block_deflate_spec.rb:46 # ZipTricks::BlockDeflate deflate_in_blocks_and_terminate uses deflate_in_blocks
rspec ./spec/zip_tricks/block_deflate_spec.rb:58 # ZipTricks::BlockDeflate deflate_in_blocks_and_terminate passes a custom compression level
rspec ./spec/zip_tricks/block_deflate_spec.rb:87 # ZipTricks::BlockDeflate.deflate_in_blocks honors the block size
rspec ./spec/zip_tricks/rails_streaming_spec.rb:4 # ZipTricks::RailsStreaming calls the requisite controller methods
rspec ./spec/zip_tricks/streamer_spec.rb:276 # ZipTricks::Streamer writes the correct archive elements when using data descriptors
rspec ./spec/zip_tricks/streamer_spec.rb:420 # ZipTricks::Streamer prevents duplicates in the stored files
rspec ./spec/zip_tricks/streamer_spec.rb:525 # ZipTricks::Streamer writes the specified modification time
```

-> I've added a new issue to address the actual fixes for Ruby 3 in a separated PR: https://github.com/WeTransfer/zip_tricks/issues/104


**update**
the actual problem (for the first spec at least) is `rspec-mocks`, in particular this line: https://github.com/rspec/rspec-mocks/blob/6ab343ca479c606e892c82ce0245e7410e3f0eac/lib/rspec/mocks/message_expectation.rb#L101

```ruby
      def and_call_original
        wrap_original(__method__) do |original, *args, &block|
          original.call(*args, &block)
        end
      end
```

which will receive the following `args`:
```ruby
[#<StringIO:0x00007ff8d713bfc8>, #<StringIO:0x00007ff8d713be88>, {:level=>-1, :block_size=>65536}]
```
hence this is expanded to 3 params, 2x a string, and a hash, which is then not splatted into kwargs.
Further research shows, there is already an Issue: https://github.com/rspec/rspec-mocks/issues/1306 with a fixing PR: https://github.com/rspec/rspec-mocks/pull/1324