### PR TITLE
upgrade rspec-mock (Ruby 3 compatibility, we can now disallow failures for Ruby 3 on CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,11 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.0'
           - '2.7'
           - '2.1'
           - 'jruby-9.2'
         experimental: [false]
-        include:
-          - ruby: 3.0
-            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 1.6' # For tests, where we spin up a server
   spec.add_development_dependency 'rake', '~> 12.2'
   spec.add_development_dependency 'rspec', '~> 3'
+  spec.add_development_dependency 'rspec-mocks', '~> 3.10', '>= 3.10.2' # ruby 3 compatibility
   spec.add_development_dependency 'complexity_assert'
   spec.add_development_dependency 'coderay'
   spec.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
Had to hard code the minimum `rspec-mock` gem version (dev dependency). Using `>= 3.10.2` all specs with Ruby 3.0 pass.

Possibly we could use [appraisal](https://github.com/thoughtbot/appraisal/) to run different requirements for different Rubies for the CI. That'll require quite some config though.

closes https://github.com/WeTransfer/zip_tricks/issues/104