### PR TITLE
Allow UNIX permissions for entries to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.6.0
+
+* Add customisable `unix_permissions` to Streamer and ZipWriter. Beware that customising these permissions can lead to the archive failing to expand with some unarchiving applications, and is especially sensitive for directories.
+
 ## 5.5.0
 
 * In `OutputEnumerator` apply some amount of buffering to be within a UNIX socket size for metatada writes. This

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -200,14 +200,16 @@ class ZipTricks::Streamer
   # @param uncompressed_size [Integer] the size of the entry when uncompressed, in bytes
   # @param crc32 [Integer] the CRC32 checksum of the entry when uncompressed
   # @param use_data_descriptor [Boolean] whether the entry body will be followed by a data descriptor
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
   # @return [Integer] the offset the output IO is at after writing the entry header
-  def add_deflated_entry(filename:, modification_time: Time.now.utc, compressed_size: 0, uncompressed_size: 0, crc32: 0, use_data_descriptor: false)
+  def add_deflated_entry(filename:, modification_time: Time.now.utc, compressed_size: 0, uncompressed_size: 0, crc32: 0, unix_permissions: nil, use_data_descriptor: false)
     add_file_and_write_local_header(filename: filename,
                                     modification_time: modification_time,
                                     crc32: crc32,
                                     storage_mode: DEFLATED,
                                     compressed_size: compressed_size,
                                     uncompressed_size: uncompressed_size,
+                                    unix_permissions: unix_permissions,
                                     use_data_descriptor: use_data_descriptor)
     @out.tell
   end
@@ -222,14 +224,16 @@ class ZipTricks::Streamer
   # @param size [Integer] the size of the file when uncompressed, in bytes
   # @param crc32 [Integer] the CRC32 checksum of the entry when uncompressed
   # @param use_data_descriptor [Boolean] whether the entry body will be followed by a data descriptor. When in use
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
   # @return [Integer] the offset the output IO is at after writing the entry header
-  def add_stored_entry(filename:, modification_time: Time.now.utc,  size: 0, crc32: 0, use_data_descriptor: false)
+  def add_stored_entry(filename:, modification_time: Time.now.utc,  size: 0, crc32: 0, unix_permissions: nil, use_data_descriptor: false)
     add_file_and_write_local_header(filename: filename,
                                     modification_time: modification_time,
                                     crc32: crc32,
                                     storage_mode: STORED,
                                     compressed_size: size,
                                     uncompressed_size: size,
+                                    unix_permissions: unix_permissions,
                                     use_data_descriptor: use_data_descriptor)
     @out.tell
   end
@@ -238,14 +242,16 @@ class ZipTricks::Streamer
   #
   # @param dirname [String] the name of the directory in the archive
   # @param modification_time [Time] the modification time of the directory in the archive
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
   # @return [Integer] the offset the output IO is at after writing the entry header
-  def add_empty_directory(dirname:, modification_time: Time.now.utc)
+  def add_empty_directory(dirname:, modification_time: Time.now.utc, unix_permissions: nil)
     add_file_and_write_local_header(filename: dirname.to_s + '/',
                                     modification_time: modification_time,
                                     crc32: 0,
                                     storage_mode: STORED,
                                     compressed_size: 0,
                                     uncompressed_size: 0,
+                                    unix_permissions: unix_permissions,
                                     use_data_descriptor: false)
     @out.tell
   end
@@ -283,14 +289,16 @@ class ZipTricks::Streamer
   #
   # @param filename[String] the name of the file in the archive
   # @param modification_time [Time] the modification time of the file in the archive
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
   # @yield [#<<, #write] an object that the file contents must be written to that will be automatically closed
   # @return [#<<, #write, #close] an object that the file contents must be written to, has to be closed manually
-  def write_stored_file(filename, modification_time: Time.now.utc)
+  def write_stored_file(filename, modification_time: Time.now.utc, unix_permissions: nil)
     add_stored_entry(filename: filename,
                      modification_time: modification_time,
                      use_data_descriptor: true,
                      crc32: 0,
-                     size: 0)
+                     size: 0,
+                     unix_permissions: unix_permissions)
 
     writable = Writable.new(self, StoredWriter.new(@out))
     if block_given?
@@ -335,14 +343,16 @@ class ZipTricks::Streamer
   #
   # @param filename[String] the name of the file in the archive
   # @param modification_time [Time] the modification time of the file in the archive
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
   # @yield [#<<, #write] an object that the file contents must be written to
-  def write_deflated_file(filename, modification_time: Time.now.utc)
+  def write_deflated_file(filename, modification_time: Time.now.utc, unix_permissions: nil)
     add_deflated_entry(filename: filename,
                        modification_time: modification_time,
                        use_data_descriptor: true,
                        crc32: 0,
                        compressed_size: 0,
-                       uncompressed_size: 0)
+                       uncompressed_size: 0,
+                       unix_permissions: unix_permissions)
 
     writable = Writable.new(self, DeflatedWriter.new(@out))
     if block_given?
@@ -375,7 +385,8 @@ class ZipTricks::Streamer
                                                   uncompressed_size: entry.uncompressed_size,
                                                   mtime: entry.mtime,
                                                   crc32: entry.crc32,
-                                                  filename: entry.filename)
+                                                  filename: entry.filename,
+                                                  unix_permissions: entry.unix_permissions)
     end
 
     # Record the central directory size, for the EOCDR
@@ -462,7 +473,8 @@ EMS
       storage_mode:,
       compressed_size:,
       uncompressed_size:,
-      use_data_descriptor:)
+      use_data_descriptor:,
+      unix_permissions:)
 
     # Clean backslashes
     filename = remove_backslash(filename)
@@ -498,7 +510,8 @@ EMS
                   use_data_descriptor,
                   _local_file_header_offset = local_header_starts_at,
                   _bytes_used_for_local_header = 0,
-                  _bytes_used_for_data_descriptor = 0)
+                  _bytes_used_for_data_descriptor = 0,
+                  unix_permissions = unix_permissions)
 
     @writer.write_local_file_header(io: @out,
                                     gp_flags: e.gp_flags,

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -200,7 +200,7 @@ class ZipTricks::Streamer
   # @param uncompressed_size [Integer] the size of the entry when uncompressed, in bytes
   # @param crc32 [Integer] the CRC32 checksum of the entry when uncompressed
   # @param use_data_descriptor [Boolean] whether the entry body will be followed by a data descriptor
-  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used
   # @return [Integer] the offset the output IO is at after writing the entry header
   def add_deflated_entry(filename:, modification_time: Time.now.utc, compressed_size: 0, uncompressed_size: 0, crc32: 0, unix_permissions: nil, use_data_descriptor: false)
     add_file_and_write_local_header(filename: filename,
@@ -224,7 +224,7 @@ class ZipTricks::Streamer
   # @param size [Integer] the size of the file when uncompressed, in bytes
   # @param crc32 [Integer] the CRC32 checksum of the entry when uncompressed
   # @param use_data_descriptor [Boolean] whether the entry body will be followed by a data descriptor. When in use
-  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used
   # @return [Integer] the offset the output IO is at after writing the entry header
   def add_stored_entry(filename:, modification_time: Time.now.utc,  size: 0, crc32: 0, unix_permissions: nil, use_data_descriptor: false)
     add_file_and_write_local_header(filename: filename,
@@ -242,7 +242,7 @@ class ZipTricks::Streamer
   #
   # @param dirname [String] the name of the directory in the archive
   # @param modification_time [Time] the modification time of the directory in the archive
-  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used
   # @return [Integer] the offset the output IO is at after writing the entry header
   def add_empty_directory(dirname:, modification_time: Time.now.utc, unix_permissions: nil)
     add_file_and_write_local_header(filename: dirname.to_s + '/',
@@ -289,7 +289,7 @@ class ZipTricks::Streamer
   #
   # @param filename[String] the name of the file in the archive
   # @param modification_time [Time] the modification time of the file in the archive
-  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used
   # @yield [#<<, #write] an object that the file contents must be written to that will be automatically closed
   # @return [#<<, #write, #close] an object that the file contents must be written to, has to be closed manually
   def write_stored_file(filename, modification_time: Time.now.utc, unix_permissions: nil)
@@ -343,7 +343,7 @@ class ZipTricks::Streamer
   #
   # @param filename[String] the name of the file in the archive
   # @param modification_time [Time] the modification time of the file in the archive
-  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used 
+  # @param unix_permissions[Fixnum?] which UNIX permissions to set, normally the default should be used
   # @yield [#<<, #write] an object that the file contents must be written to
   def write_deflated_file(filename, modification_time: Time.now.utc, unix_permissions: nil)
     add_deflated_entry(filename: filename,
@@ -511,7 +511,7 @@ EMS
                   _local_file_header_offset = local_header_starts_at,
                   _bytes_used_for_local_header = 0,
                   _bytes_used_for_data_descriptor = 0,
-                  unix_permissions = unix_permissions)
+                  unix_permissions)
 
     @writer.write_local_file_header(io: @out,
                                     gp_flags: e.gp_flags,

--- a/lib/zip_tricks/streamer/entry.rb
+++ b/lib/zip_tricks/streamer/entry.rb
@@ -4,7 +4,7 @@
 # Normally you will not have to use this class directly
 class ZipTricks::Streamer::Entry < Struct.new(:filename, :crc32, :compressed_size,
                                               :uncompressed_size, :storage_mode, :mtime,
-                                              :use_data_descriptor, :local_header_offset, :bytes_used_for_local_header, :bytes_used_for_data_descriptor)
+                                              :use_data_descriptor, :local_header_offset, :bytes_used_for_local_header, :bytes_used_for_data_descriptor, :unix_permissions)
   def initialize(*)
     super
     filename.force_encoding(Encoding::UTF_8)

--- a/lib/zip_tricks/version.rb
+++ b/lib/zip_tricks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipTricks
-  VERSION = '5.5.0'
+  VERSION = '5.6.0'
 end

--- a/lib/zip_tricks/zip_writer.rb
+++ b/lib/zip_tricks/zip_writer.rb
@@ -137,7 +137,7 @@ class ZipTricks::ZipWriter
                                           crc32:,
                                           filename:,
                                           unix_permissions: nil
-                                          )
+                                         )
     # At this point if the header begins somewhere beyound 0xFFFFFFFF we _have_ to record the offset
     # of the local file header as a zip64 extra field, so we give up, give in, you loose, love will always win...
     add_zip64 = (local_file_header_location > FOUR_BYTE_MAX_UINT) ||

--- a/lib/zip_tricks/zip_writer.rb
+++ b/lib/zip_tricks/zip_writer.rb
@@ -31,22 +31,10 @@ class ZipTricks::ZipWriter
   VERSION_MADE_BY                        = 52
   VERSION_NEEDED_TO_EXTRACT              = 20
   VERSION_NEEDED_TO_EXTRACT_ZIP64        = 45
-  DEFAULT_EXTERNAL_ATTRS = begin
-    # These need to be set so that the unarchived files do not become executable on UNIX, for
-    # security purposes. Strictly speaking we would want to make this user-customizable,
-    # but for now just putting in sane defaults will do. For example, Trac with zipinfo does this:
-    # zipinfo.external_attr = 0644 << 16L # permissions -r-wr--r--.
-    # We snatch the incantations from Rubyzip for this.
-    unix_perms = 0o644
-    file_type_file = 0o10
-    (file_type_file << 12 | (unix_perms & 0o7777)) << 16
-  end
-  EMPTY_DIRECTORY_EXTERNAL_ATTRS = begin
-    # Applies permissions to an empty directory.
-    unix_perms = 0o755
-    file_type_dir = 0o04
-    (file_type_dir << 12 | (unix_perms & 0o7777)) << 16
-  end
+  DEFAULT_FILE_UNIX_PERMISSIONS = 0o644
+  DEFAULT_DIRECTORY_UNIX_PERMISSIONS = 0o755
+  FILE_TYPE_FILE = 0o10
+  FILE_TYPE_DIRECTORY = 0o04
   MADE_BY_SIGNATURE = begin
     # A combination of the VERSION_MADE_BY low byte and the OS type high byte
     os_type = 3 # UNIX
@@ -64,7 +52,8 @@ class ZipTricks::ZipWriter
                    :VERSION_MADE_BY,
                    :VERSION_NEEDED_TO_EXTRACT,
                    :VERSION_NEEDED_TO_EXTRACT_ZIP64,
-                   :DEFAULT_EXTERNAL_ATTRS,
+                   :FILE_TYPE_FILE,
+                   :FILE_TYPE_DIRECTORY,
                    :MADE_BY_SIGNATURE,
                    :C_UINT4,
                    :C_UINT2,
@@ -136,6 +125,7 @@ class ZipTricks::ZipWriter
   # @param crc32[Fixnum] The CRC32 checksum of the file
   # @param mtime[Time]  the modification time to be recorded in the ZIP
   # @param gp_flags[Fixnum] bit-packed general purpose flags
+  # @param unix_permissions[Fixnum?] the permissions for the file, or nil for the default to be used
   # @return [void]
   def write_central_directory_file_header(io:,
                                           local_file_header_location:,
@@ -145,7 +135,9 @@ class ZipTricks::ZipWriter
                                           uncompressed_size:,
                                           mtime:,
                                           crc32:,
-                                          filename:)
+                                          filename:,
+                                          unix_permissions: nil
+                                          )
     # At this point if the header begins somewhere beyound 0xFFFFFFFF we _have_ to record the offset
     # of the local file header as a zip64 extra field, so we give up, give in, you loose, love will always win...
     add_zip64 = (local_file_header_location > FOUR_BYTE_MAX_UINT) ||
@@ -200,11 +192,15 @@ class ZipTricks::ZipWriter
 
     # Because the add_empty_directory method will create a directory with a trailing "/",
     # this check can be used to assign proper permissions to the created directory.
-    io << if filename.end_with?('/')
-      [EMPTY_DIRECTORY_EXTERNAL_ATTRS].pack(C_UINT4)
+    # external file attributes        4 bytes
+    external_attrs = if filename.end_with?('/')
+      unix_permissions ||= DEFAULT_DIRECTORY_UNIX_PERMISSIONS
+      generate_external_attrs(unix_permissions, FILE_TYPE_DIRECTORY)
     else
-      [DEFAULT_EXTERNAL_ATTRS].pack(C_UINT4)           # external file attributes        4 bytes
+      unix_permissions ||= DEFAULT_FILE_UNIX_PERMISSIONS
+      generate_external_attrs(unix_permissions, FILE_TYPE_FILE)
     end
+    io << [external_attrs].pack(C_UINT4)
 
     io << if add_zip64                                 # relative offset of local header 4 bytes
       [FOUR_BYTE_MAX_UINT].pack(C_UINT4)
@@ -433,5 +429,9 @@ class ZipTricks::ZipWriter
   def pack_array(values_to_packspecs)
     values, packspecs = values_to_packspecs.partition.each_with_index { |_, i| i.even? }
     values.pack(packspecs.join)
+  end
+
+  def generate_external_attrs(unix_permissions_int, file_type_int)
+    (file_type_int << 12 | (unix_permissions_int & 0o7777)) << 16
   end
 end


### PR DESCRIPTION
Since we now have permissions in Storm it makes sense to support them natively. This will also allow the fork in https://github.com/retrospectinc/zip_tricks to be dropped, since this is a feature they had to add