### PR TITLE
Update CI to include Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,13 @@ jobs:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
+      fail-fast: false
       matrix:
         ruby:
+          - '3.1'
           - '3.0'
           - '2.7'
-          - '2.1'
+          - 'jruby-9.3'
           - 'jruby-9.2'
         experimental: [false]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - '2.7'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -69,7 +69,7 @@ jobs:
         experimental: [false]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
           - '2.7'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Gemfile Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: Gemfile.lock
           key: ${{ runner.os }}-gemlock-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'zip_tricks.gemspec') }}
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-gemlock-${{ matrix.ruby }}-
       - name: Bundle Cache
         id: cache-gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'Gemfile.lock', 'zip_tricks.gemspec') }}
@@ -43,7 +43,7 @@ jobs:
         if: steps.cache-gems.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
       - name: Rubocop Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/rubocop_cache
           key: ${{ runner.os }}-rubocop-${{ hashFiles('.rubocop.yml') }}
@@ -59,21 +59,23 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'
+          - 'jruby-9.4'
           - 'jruby-9.3'
           - 'jruby-9.2'
         experimental: [false]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Gemfile Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: Gemfile.lock
           key: ${{ runner.os }}-gemlock-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'zip_tricks.gemspec') }}
@@ -81,7 +83,7 @@ jobs:
             ${{ runner.os }}-gemlock-${{ matrix.ruby }}-
       - name: Bundle Cache
         id: cache-gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'Gemfile.lock', 'zip_tricks.gemspec') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: bundle exec rubocop
   test:
     name: Specs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   lint:
     name: Code Style
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
           - '2.7'
           - 'jruby-9.4'
           - 'jruby-9.3'
-          - 'jruby-9.2'
         experimental: [false]
     steps:
       - name: Checkout

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_gem:
   wetransfer_style: ruby/default.yml
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.5
 Layout/FirstMethodArgumentLineBreak:
   Enabled: false
 Layout/FirstMethodParameterLineBreak:
@@ -11,5 +11,5 @@ Style/GlobalVars:
       - qa/*.rb
       - spec/spec_helper.rb
       - spec/support/zip_inspection.rb
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'yard'
 require 'rubocop/rake_task'
+require 'yard'
 
 YARD::Rake::YardocTask.new(:doc) do |t|
   # The dash has to be between the two to "divide" the source files and

--- a/examples/rack_application.rb
+++ b/examples/rack_application.rb
@@ -36,20 +36,19 @@ class ZipDownload
 
     # Create a suitable Rack response body, that will support each(),
     # close() and all the other methods. We can then return it up the stack.
-    zip_response_body = ZipTricks::Streamer.output_enum do |zip|
-      begin
-        # We are adding only one file to the ZIP here, but you could do that
-        # with an arbitrary number of files of course.
-        zip.add_stored_entry(filename: filename, size: f.size, crc32: crc32)
-        # Write the contents of the file. It is stored, so the writes go
-        # directly to the Rack output, bypassing any RubyZip
-        # deflaters/compressors. In fact you are yielding the "blob" string
-        # here directly to the Rack server handler.
-        IO.copy_stream(f, zip)
+    zip_response_body =
+      # We are adding only one file to the ZIP here, but you could do that
+      # with an arbitrary number of files of course.
+      ZipTricks::Streamer.output_enum do |zip|
+    zip.add_stored_entry(filename: filename, size: f.size, crc32: crc32)
+    # Write the contents of the file. It is stored, so the writes go
+    # directly to the Rack output, bypassing any RubyZip
+    # deflaters/compressors. In fact you are yielding the "blob" string
+    # here directly to the Rack server handler.
+    IO.copy_stream(f, zip)
       ensure
-        f.close # Make sure the opened file we read from gets closed
-      end
-    end
+      f.close # Make sure the opened file we read from gets closed
+  end
 
     # Add a Content-Disposition so that the download has a .zip extension
     # (this will not work well with UTF-8 filenames on Windows, but hey!)

--- a/lib/zip_tricks/file_reader.rb
+++ b/lib/zip_tricks/file_reader.rb
@@ -63,8 +63,8 @@ require 'stringio'
 # it involves a much larger number of reads (1 read from the IO per entry in the ZIP).
 
 class ZipTricks::FileReader
-  require_relative 'file_reader/stored_reader'
   require_relative 'file_reader/inflating_reader'
+  require_relative 'file_reader/stored_reader'
 
   ReadError = Class.new(StandardError)
   UnsupportedFeature = Class.new(StandardError)
@@ -608,7 +608,7 @@ class ZipTricks::FileReader
     end
 
     # If the offset is negative there is certainly no Zip64 EOCD locator here
-    return unless zip64_eocd_loc_offset >= 0
+    return if zip64_eocd_loc_offset < 0
 
     file_io.seek(zip64_eocd_loc_offset, IO::SEEK_SET)
     assert_signature(file_io, 0x07064b50)

--- a/lib/zip_tricks/size_estimator.rb
+++ b/lib/zip_tricks/size_estimator.rb
@@ -43,9 +43,7 @@ class ZipTricks::SizeEstimator
                                size: size,
                                use_data_descriptor: use_data_descriptor)
     @streamer.simulate_write(size)
-    if use_data_descriptor
-      @streamer.update_last_entry_and_write_data_descriptor(crc32: 0, compressed_size: size, uncompressed_size: size)
-    end
+    @streamer.update_last_entry_and_write_data_descriptor(crc32: 0, compressed_size: size, uncompressed_size: size) if use_data_descriptor
     self
   end
 

--- a/lib/zip_tricks/stream_crc32.rb
+++ b/lib/zip_tricks/stream_crc32.rb
@@ -5,7 +5,7 @@ class ZipTricks::StreamCRC32
   STRINGS_HAVE_CAPACITY_SUPPORT = begin
     String.new('', capacity: 1)
     true
-  rescue ArgumentError
+                                  rescue ArgumentError
     false
   end
   CRC_BUF_SIZE = 1024 * 512

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -467,14 +467,14 @@ EMS
   end
 
   def add_file_and_write_local_header(
-      filename:,
-      modification_time:,
-      crc32:,
-      storage_mode:,
-      compressed_size:,
-      uncompressed_size:,
-      use_data_descriptor:,
-      unix_permissions:)
+    filename:,
+    modification_time:,
+    crc32:,
+    storage_mode:,
+    compressed_size:,
+    uncompressed_size:,
+    use_data_descriptor:,
+    unix_permissions:)
 
     # Clean backslashes
     filename = remove_backslash(filename)

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -80,9 +80,9 @@ require 'set'
 # Calling {Streamer#close} **will not** call `#close` on the underlying IO object.
 class ZipTricks::Streamer
   require_relative 'streamer/deflated_writer'
-  require_relative 'streamer/writable'
-  require_relative 'streamer/stored_writer'
   require_relative 'streamer/entry'
+  require_relative 'streamer/stored_writer'
+  require_relative 'streamer/writable'
 
   STORED = 0
   DEFLATED = 8

--- a/lib/zip_tricks/zip_writer.rb
+++ b/lib/zip_tricks/zip_writer.rb
@@ -104,9 +104,7 @@ class ZipTricks::ZipWriter
     # https://social.technet.microsoft.com/Forums/windows/en-US/6a60399f-2879-4859-b7ab-6ddd08a70948
     # TL;DR of it is: Windows 7 Explorer _will_ open Zip64 entries. However, it desires to have the
     # Zip64 extra field as _the first_ extra field.
-    if requires_zip64
-      extra_fields << zip_64_extra_for_local_file_header(compressed_size: compressed_size, uncompressed_size: uncompressed_size)
-    end
+    extra_fields << zip_64_extra_for_local_file_header(compressed_size: compressed_size, uncompressed_size: uncompressed_size) if requires_zip64
     extra_fields << timestamp_extra_for_local_file_header(mtime)
 
     io << [extra_fields.size].pack(C_UINT2)                # extra field length              2 bytes

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,17 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-require 'rspec'
-require 'zip_tricks'
 require 'digest'
 require 'fileutils'
+require 'rspec'
 require 'shellwords'
 require 'zip'
+require 'zip_tricks'
 
-require_relative 'support/read_monitor'
-require_relative 'support/managed_tempfile'
-require_relative 'support/zip_inspection'
 require_relative 'support/allocate_under_matcher'
+require_relative 'support/managed_tempfile'
+require_relative 'support/read_monitor'
+require_relative 'support/zip_inspection'
 
 RSpec.configure do |config|
   config.include ZipInspection

--- a/spec/support/allocate_under_matcher.rb
+++ b/spec/support/allocate_under_matcher.rb
@@ -2,9 +2,7 @@ require 'allocation_stats' if RUBY_ENGINE == 'ruby'
 
 RSpec::Matchers.define :allocate_under do |expected|
   match do |actual|
-    unless RUBY_ENGINE == 'ruby'
-      skip "allocation tracing not supported on #{RUBY_ENGINE}"
-    end
+    skip "allocation tracing not supported on #{RUBY_ENGINE}" unless RUBY_ENGINE == 'ruby'
     @trace = actual.is_a?(Proc) ? AllocationStats.trace(&actual) : actual
     @trace.new_allocations.size < expected
   end

--- a/spec/support/managed_tempfile.rb
+++ b/spec/support/managed_tempfile.rb
@@ -8,12 +8,10 @@ class ManagedTempfile < Tempfile
 
   def self.prune!
     @@managed_tempfiles.each do |tf|
-      begin
         tf.close
         tf.unlink
-      rescue
+    rescue
         nil
-      end
     end
     @@managed_tempfiles.clear
   end

--- a/spec/zip_tricks/remote_io_spec.rb
+++ b/spec/zip_tricks/remote_io_spec.rb
@@ -12,7 +12,6 @@ describe ZipTricks::RemoteIO do
 
     it 'performs remote reads when repeatedly requesting the same chunk, via \
         #request_range' do
-
       expect(subject).to receive(:request_object_size).and_return(120)
       allow(subject).to receive(:request_range) { |range|
         expect(range).to eq(5..14)

--- a/spec/zip_tricks/remote_uncap_spec.rb
+++ b/spec/zip_tricks/remote_uncap_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
 require 'net/http'
+require 'spec_helper'
 
 describe ZipTricks::RemoteUncap do
   before :all do

--- a/spec/zip_tricks/remote_uncap_spec.rb
+++ b/spec/zip_tricks/remote_uncap_spec.rb
@@ -32,10 +32,8 @@ describe ZipTricks::RemoteUncap do
   end
 
   after :each do
-    begin
       File.unlink('temp.zip')
-    rescue Errno::ENOENT
-    end
+  rescue Errno::ENOENT
   end
 
   it 'returns an array of remote entries that can be used to fetch the segments \

--- a/spec/zip_tricks/streamer/deflated_writer_spec.rb
+++ b/spec/zip_tricks/streamer/deflated_writer_spec.rb
@@ -11,7 +11,7 @@ describe ZipTricks::Streamer::DeflatedWriter do
 
     finish_result = subject.finish
 
-    zlib_inflater = ::Zlib::Inflate.new(-Zlib::MAX_WBITS)
+    zlib_inflater = Zlib::Inflate.new(-Zlib::MAX_WBITS)
     inflated = zlib_inflater.inflate(out.string)
     expect(inflated).to eq(('a' * 256) + ('b' * 256) + ('b' * 256))
 

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -524,19 +524,20 @@ describe ZipTricks::Streamer do
 
   it 'writes the specified modification time', :aggregate_failures do
     fake_writer = double('Writer').as_null_object
+    modification_time = Time.new(2018, 1, 1, 0, 0, 0, '+00:00')
 
     expect(fake_writer).to receive(:write_local_file_header) { |**kwargs|
-      expect(kwargs[:mtime]).to eq(Time.new('2018-01-01 00:00:00'))
+      expect(kwargs[:mtime]).to eq(modification_time)
     }.exactly(3).times
 
     described_class.open(StringIO.new, writer: fake_writer) do |zip|
-      zip.write_stored_file('stored.txt', modification_time: Time.new('2018-01-01 00:00:00')) do |sink|
+      zip.write_stored_file('stored.txt', modification_time: modification_time) do |sink|
         sink << 'stored'
       end
-      zip.write_deflated_file('deflated.txt', modification_time: Time.new('2018-01-01 00:00:00')) do |sink|
+      zip.write_deflated_file('deflated.txt', modification_time: modification_time) do |sink|
         sink << 'deflated'
       end
-      zip.add_empty_directory(dirname: 'empty', modification_time: Time.new('2018-01-01 00:00:00'))
+      zip.add_empty_directory(dirname: 'empty', modification_time: modification_time)
     end
   end
 end

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -42,6 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'allocation_stats', '~> 0.1.5'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'wetransfer_style', '0.6.0'
+  spec.add_development_dependency 'wetransfer_style', '~> 1.0'
   spec.add_development_dependency 'puma'
 end

--- a/zip_tricks.gemspec
+++ b/zip_tricks.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rubyzip', '~> 1'
 
-  spec.add_development_dependency 'rack', '~> 1.6' # For tests, where we spin up a server
-  spec.add_development_dependency 'rake', '~> 12.2'
+  spec.add_development_dependency 'rack', '>= 1.6' # For tests, where we spin up a server
+  spec.add_development_dependency 'rake', '>= 12.2'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec-mocks', '~> 3.10', '>= 3.10.2' # ruby 3 compatibility
   spec.add_development_dependency 'complexity_assert'
@@ -42,6 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'allocation_stats', '~> 0.1.5'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'wetransfer_style', '~> 1.0'
+  spec.add_development_dependency 'wetransfer_style', '~> 2.1'
   spec.add_development_dependency 'puma'
 end


### PR DESCRIPTION
This PR updates the CI configuration to include Ruby 3.1

Other changes include:

1. Updating the wetransfer_style gem to a ~> 1.0 version
2. Removing the 2.1 in the CI configuration, as that is not supported by the underlying Rubocop version
3. Addressing all open lints from the wetransfer_style upgrade
4. Adding JRuby 9.3
5. Making a change in a spec to avoid use of a constructor for Time that doesn't exist in Ruby 3.1