### PR TITLE
Fix usage of Time.new in tests

### DIFF
--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -526,17 +526,17 @@ describe ZipTricks::Streamer do
     fake_writer = double('Writer').as_null_object
 
     expect(fake_writer).to receive(:write_local_file_header) { |**kwargs|
-      expect(kwargs[:mtime]).to eq(Time.new('2018-01-01 00:00:00'))
+      expect(kwargs[:mtime]).to eq(Time.new(2018, 1, 1))
     }.exactly(3).times
 
     described_class.open(StringIO.new, writer: fake_writer) do |zip|
-      zip.write_stored_file('stored.txt', modification_time: Time.new('2018-01-01 00:00:00')) do |sink|
+      zip.write_stored_file('stored.txt', modification_time: Time.new(2018, 1, 1)) do |sink|
         sink << 'stored'
       end
-      zip.write_deflated_file('deflated.txt', modification_time: Time.new('2018-01-01 00:00:00')) do |sink|
+      zip.write_deflated_file('deflated.txt', modification_time: Time.new(2018, 1, 1)) do |sink|
         sink << 'deflated'
       end
-      zip.add_empty_directory(dirname: 'empty', modification_time: Time.new('2018-01-01 00:00:00'))
+      zip.add_empty_directory(dirname: 'empty', modification_time: Time.new(2018, 1, 1))
     end
   end
 end


### PR DESCRIPTION
as it was no longer compatible with Ruby 3.x