### PR TITLE
Allow objects that only write() as destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ the metadata of the file upfront (the CRC32 of the uncompressed file and the siz
 to that socket using some accelerated writing technique, and only use the Streamer to write out the ZIP metadata.
 
 ```ruby
-# io has to be an object that supports #<<
+# io has to be an object that supports #<< or #write()
 ZipTricks::Streamer.open(io) do | zip |
   # raw_file is written "as is" (STORED mode).
   # Write the local file header first..

--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -145,7 +145,8 @@ class ZipTricks::Streamer
   #    should be suffixed with (1), (2) etc. Default value is `false` - if
   #    dupliate names are used an exception will be raised
   def initialize(writable, writer: create_writer, auto_rename_duplicate_filenames: false)
-    raise InvalidOutput, 'The writable must respond to #<<' unless writable.respond_to?(:<<)
+    raise InvalidOutput, 'The writable must respond to #<< or #write' unless writable.respond_to?(:<<) || writable.respond_to?(:write)
+
     @out = ZipTricks::WriteAndTell.new(writable)
     @files = []
     @path_set = ZipTricks::PathSet.new

--- a/lib/zip_tricks/write_and_tell.rb
+++ b/lib/zip_tricks/write_and_tell.rb
@@ -6,11 +6,20 @@ class ZipTricks::WriteAndTell
   def initialize(io)
     @io = io
     @pos = 0
+    # Some objects (such as ActionController::Live `stream` object) cannot be "pushed" into
+    # using the :<< operator, but only support `write`. For ease we add a small shim in that case instead of having
+    # the user abstract it themselves.
+    @use_write = !io.respond_to?(:<<)
   end
 
   def <<(bytes)
     return self if bytes.nil?
-    @io << bytes.b
+    if @use_write
+      @io.write(bytes.b)
+    else
+      @io << bytes.b
+    end
+
     @pos += bytes.bytesize
     self
   end

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -50,6 +50,17 @@ describe ZipTricks::Streamer do
     expect { described_class.new(nil) }.to raise_error(ZipTricks::Streamer::InvalidOutput)
   end
 
+  it 'allows a destination which only supports write()' do
+    stream_with_just_write = Object.new
+    def stream_with_just_write.write(bytes)
+      # noop
+    end
+
+    expect {
+      described_class.new(stream_with_just_write)
+    }.not_to raise_error
+  end
+
   it 'allows the writer to be injectable' do
     fake_writer = double('ZipWriter')
     expect(fake_writer).to receive(:write_local_file_header)

--- a/spec/zip_tricks/write_and_tell_spec.rb
+++ b/spec/zip_tricks/write_and_tell_spec.rb
@@ -45,6 +45,20 @@ describe ZipTricks::WriteAndTell do
     expect(writer.tell).to eq(33)
   end
 
+  it 'is able to write into an object which only supports write()' do
+    stream_with_just_write = Object.new
+    def stream_with_just_write.write(bytes)
+      # noop
+    end
+
+    writer = described_class.new(stream_with_just_write)
+    writer << 'Hello'
+    writer << 'Goodbye'
+    writer << 'What a day!'
+    writer.advance_position_by(10)
+    expect(writer.tell).to eq(33)
+  end
+
   it 'advances the internal pointer using advance_position_by' do
     str = ''
 


### PR DESCRIPTION
Some objects - such as the Rails stream object - do not support the <<, but do support write(). We can add a small shim into our stack to account for this, with the cost of a single respond_to? call at Streamer initialization.