### PR TITLE
Update README with the new project name/URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,93 +2,26 @@ name: CI
 
 on:
   - push
-  - pull_request
 
 env:
   BUNDLE_PATH: vendor/bundle
 
 jobs:
-  lint:
-    name: Code Style
-    runs-on: ubuntu-18.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      matrix:
-        ruby:
-          - '2.7'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: Gemfile Cache
-        uses: actions/cache@v2
-        with:
-          path: Gemfile.lock
-          key: ${{ runner.os }}-gemlock-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'zip_tricks.gemspec') }}
-          restore-keys: |
-            ${{ runner.os }}-gemlock-${{ matrix.ruby }}-
-      - name: Bundle Cache
-        id: cache-gems
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'Gemfile.lock', 'zip_tricks.gemspec') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ matrix.ruby }}-
-            ${{ runner.os }}-gems-
-      - name: Bundle Install
-        if: steps.cache-gems.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
-      - name: Rubocop Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/rubocop_cache
-          key: ${{ runner.os }}-rubocop-${{ hashFiles('.rubocop.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-rubocop-
-      - name: Rubocop
-        run: bundle exec rubocop
   test:
-    name: Specs
-    runs-on: ubuntu-18.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    name: Tests and Lint
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby:
-          - '3.0'
-          - '2.7'
-          - '2.1'
-          - 'jruby-9.2'
-        experimental: [false]
+          - '2.6'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Gemfile Cache
-        uses: actions/cache@v2
-        with:
-          path: Gemfile.lock
-          key: ${{ runner.os }}-gemlock-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'zip_tricks.gemspec') }}
-          restore-keys: |
-            ${{ runner.os }}-gemlock-${{ matrix.ruby }}-
-      - name: Bundle Cache
-        id: cache-gems
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'Gemfile.lock', 'zip_tricks.gemspec') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ matrix.ruby }}-
-            ${{ runner.os }}-gems-
-      - name: Bundle Install
-        if: steps.cache-gems.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
-      - name: RSpec
-        continue-on-error: ${{ matrix.experimental }}
-        run: bundle exec rspec
+          bundler-cache: true
+      - name: "Tests"
+        run: bundle exec rspec --backtrace --fail-fast
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 zip_tricks will not receive further updates or support, and will no longer be maintained. The story of zip_tricks continues
 in [zip_kit](https://github.com/julik/zip_kit) which is going to be receiving regular updates and supports all
-of the zip_tricks functionality (and more). Thank you for being part of the community to date!
+of the zip_tricks functionality (and more). Thank you for being part of the zip_tricks community!
 
 [![Gem Version](https://badge.fury.io/rb/zip_tricks.svg)](https://badge.fury.io/rb/zip_tricks)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # zip_tricks
 
-### zip_tricks will not receive further updates or support, and will no longer be maintained. The repository remains public, inviting the community to fork and continue its journey. Thank you for being part of the community to date.
+## ⚠️ Deprecation notice
 
-[![CI](https://github.com/WeTransfer/zip_tricks/actions/workflows/ci.yml/badge.svg)](https://github.com/WeTransfer/zip_tricks/actions/workflows/ci.yml)
+zip_tricks will not receive further updates or support, and will no longer be maintained. The story of zip_tricks continues
+in [zip_kit](https://github.com/julik/zip_kit) which is going to be receiving regular updates and supports all
+of the zip_tricks functionality (and more). Thank you for being part of the community to date!
+
 [![Gem Version](https://badge.fury.io/rb/zip_tricks.svg)](https://badge.fury.io/rb/zip_tricks)
+
+--------------
 
 Allows streaming, non-rewinding ZIP file output from Ruby.
 


### PR DESCRIPTION
I have undertaken a friendly fork of zip_tricks, this updates the README with the new project URL.